### PR TITLE
avoid panic with better path len check

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -23,7 +23,7 @@ func stringToBytes(s string) ([]byte, error) {
 	// consume first empty elem
 	sp = sp[1:]
 
-	for len(sp) > 0 {
+	for len(sp) > 1 {
 		p := ProtocolWithName(sp[0])
 		if p == nil {
 			return nil, fmt.Errorf("no protocol with name %s", sp[0])


### PR DESCRIPTION
This panicked before if I did eg. `ipfs bootstrap add /ip4/someip` or `ipfs bootstrap add /ip4/someip/tcp/4001`. Basically if there wasn't a trailing slash or a proper multihash. The loop references two elements anyways, so this is the proper length check. 
