### PR TITLE
added unix path protocol

### DIFF
--- a/multiaddr.go
+++ b/multiaddr.go
@@ -144,7 +144,7 @@ func (m *multiaddr) ValueForProtocol(code int) (string, error) {
 			if p.Size == 0 {
 				return "", nil
 			}
-			return strings.Split(sub.String(), "/")[2], nil
+			return strings.SplitN(sub.String(), "/", 3)[2], nil
 		}
 	}
 

--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -43,6 +43,8 @@ func TestConstructFails(t *testing.T) {
 		"/ip4/127.0.0.1/tcp",
 		"/ip4/127.0.0.1/ipfs",
 		"/ip4/127.0.0.1/ipfs/tcp",
+		"/unix",
+		"/ip4/1.2.3.4/tcp/80/unix",
 	}
 
 	for _, a := range cases {
@@ -81,6 +83,10 @@ func TestConstructSucceeds(t *testing.T) {
 		"/ip4/127.0.0.1/tcp/1234/",
 		"/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
 		"/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+		"/unix/a/b/c/d/e",
+		"/unix/stdio",
+		"/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
+		"/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
 	}
 
 	for _, a := range cases {
@@ -353,6 +359,10 @@ func TestGetValue(t *testing.T) {
 	assertValueForProto(t, a, P_IP4, "0.0.0.0")
 	assertValueForProto(t, a, P_UDP, "12345")
 	assertValueForProto(t, a, P_UTP, "")
+
+	a = newMultiaddr(t, "/ip4/0.0.0.0/unix/a/b/c/d") // ending in a path one.
+	assertValueForProto(t, a, P_IP4, "0.0.0.0")
+	assertValueForProto(t, a, P_UNIX, "a/b/c/d")
 }
 
 func TestFuzzBytes(t *testing.T) {

--- a/protocols.csv
+++ b/protocols.csv
@@ -1,4 +1,5 @@
 code	size	name
+
 4	32	ip4
 6	16	tcp
 17	16	udp
@@ -7,6 +8,7 @@ code	size	name
 132	16	sctp
 301	0	utp
 302	0	udt
+400 V unix
 421	V	ipfs
 480	0	http
 443	0	https

--- a/protocols.go
+++ b/protocols.go
@@ -12,6 +12,7 @@ type Protocol struct {
 	Size  int // a size of -1 indicates a length-prefixed variable size
 	Name  string
 	VCode []byte
+	Path  bool // indicates a path protocol (eg unix, http)
 }
 
 // replicating table here to:
@@ -27,6 +28,7 @@ const (
 	P_SCTP  = 132
 	P_UTP   = 301
 	P_UDT   = 302
+	P_UNIX  = 400
 	P_IPFS  = 421
 	P_HTTP  = 480
 	P_HTTPS = 443
@@ -40,19 +42,20 @@ const (
 
 // Protocols is the list of multiaddr protocols supported by this module.
 var Protocols = []Protocol{
-	Protocol{P_IP4, 32, "ip4", CodeToVarint(P_IP4)},
-	Protocol{P_TCP, 16, "tcp", CodeToVarint(P_TCP)},
-	Protocol{P_UDP, 16, "udp", CodeToVarint(P_UDP)},
-	Protocol{P_DCCP, 16, "dccp", CodeToVarint(P_DCCP)},
-	Protocol{P_IP6, 128, "ip6", CodeToVarint(P_IP6)},
+	Protocol{P_IP4, 32, "ip4", CodeToVarint(P_IP4), false},
+	Protocol{P_TCP, 16, "tcp", CodeToVarint(P_TCP), false},
+	Protocol{P_UDP, 16, "udp", CodeToVarint(P_UDP), false},
+	Protocol{P_DCCP, 16, "dccp", CodeToVarint(P_DCCP), false},
+	Protocol{P_IP6, 128, "ip6", CodeToVarint(P_IP6), false},
 	// these require varint:
-	Protocol{P_SCTP, 16, "sctp", CodeToVarint(P_SCTP)},
-	Protocol{P_ONION, 96, "onion", CodeToVarint(P_ONION)},
-	Protocol{P_UTP, 0, "utp", CodeToVarint(P_UTP)},
-	Protocol{P_UDT, 0, "udt", CodeToVarint(P_UDT)},
-	Protocol{P_HTTP, 0, "http", CodeToVarint(P_HTTP)},
-	Protocol{P_HTTPS, 0, "https", CodeToVarint(P_HTTPS)},
-	Protocol{P_IPFS, LengthPrefixedVarSize, "ipfs", CodeToVarint(P_IPFS)},
+	Protocol{P_SCTP, 16, "sctp", CodeToVarint(P_SCTP), false},
+	Protocol{P_ONION, 96, "onion", CodeToVarint(P_ONION), false},
+	Protocol{P_UTP, 0, "utp", CodeToVarint(P_UTP), false},
+	Protocol{P_UDT, 0, "udt", CodeToVarint(P_UDT), false},
+	Protocol{P_HTTP, 0, "http", CodeToVarint(P_HTTP), false},
+	Protocol{P_HTTPS, 0, "https", CodeToVarint(P_HTTPS), false},
+	Protocol{P_IPFS, LengthPrefixedVarSize, "ipfs", CodeToVarint(P_IPFS), false},
+	Protocol{P_UNIX, LengthPrefixedVarSize, "unix", CodeToVarint(P_UNIX), true},
 }
 
 func AddProtocol(p Protocol) error {


### PR DESCRIPTION
This PR:
- introduces the concept of a "path protocol"
- adds `unix` as a "path protocol"

Path Protocols are terminal protocols, similar to varint length
protocols (such as ipfs), but which in this case want to preserve
string addresses with `/` (slashes) in them. Such multiaddrs look
like this:

    /unix/stdio
    /unix/foo/bar/baz.sock
    /ip4/1.2.3.4/tcp/1234/unix/foo.sock
    /ip4/1.2.3.4/tcp/80/ws/a/b/c

It can also be used for websockets, http, and more.

I'm not yet convinced this is the right way to deal with path protocols
because they force the multiaddr to be terminal (i.e. no more addrs can
be added after). Eg these would be ambiguous, so they're defined to be
part of the path protocol

    /unix/a/b/c/ip4/1.2.3.4/tcp/8080
    # this means a "unix" addr with path "/a/b/c/ip4/1.2.3.4/tcp/8080"
    # NOT: a "unix" addr with path "/a/b/c", then an ip and tcp addrs.