### PR TITLE
fix udt<->utp inconsistency in protocols.{go,csv}

### DIFF
--- a/protocols.csv
+++ b/protocols.csv
@@ -5,8 +5,8 @@ code	size	name
 33	16	dccp
 41	128	ip6
 132	16	sctp
-301	0	udt
-302	0	utp
+301	0	utp
+302	0	udt
 421	V	ipfs
 480	0	http
 443	0	https


### PR DESCRIPTION
`protocols.go` said
```
	Protocol{P_UTP, 0, "utp", CodeToVarint(P_UTP)},
	Protocol{P_UDT, 0, "udt", CodeToVarint(P_UDT)},
```
and `protocols.csv` said
```
301	0	udt
302	0	utp
```