### PR TITLE
preallocate protocol slice

### DIFF
--- a/multiaddr.go
+++ b/multiaddr.go
@@ -69,15 +69,6 @@ func (m *multiaddr) String() string {
 // Protocols returns the list of protocols this Multiaddr has.
 // will panic in case we access bytes incorrectly.
 func (m *multiaddr) Protocols() []Protocol {
-
-	// panic handler, in case we try accessing bytes incorrectly.
-	defer func() {
-		if e := recover(); e != nil {
-			err := e.(error)
-			panic("Multiaddr.Protocols error: " + err.Error())
-		}
-	}()
-
 	ps := make([]Protocol, 0, 8)
 	b := m.bytes
 	for len(b) > 0 {

--- a/multiaddr.go
+++ b/multiaddr.go
@@ -78,7 +78,7 @@ func (m *multiaddr) Protocols() []Protocol {
 		}
 	}()
 
-	var ps []Protocol
+	ps := make([]Protocol, 0, 8)
 	b := m.bytes
 	for len(b) > 0 {
 		code, n, err := ReadVarintCode(b)


### PR DESCRIPTION
This was showing up on CPU profiles as a significant source of repeated allocations. We don't really care about over allocation (don't keep these slices around) and should rarely have more than 8 protocols in a single address.