### PR TITLE
store Multiaddrs as strings and don't use interfaces

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -26,7 +26,7 @@ func stringToMultiaddr(s string) (multiaddr, error) {
 		if p.Code == 0 {
 			return "", fmt.Errorf("no protocol with name %s", sp[0])
 		}
-		b.Write(CodeToVarint(p.Code))
+		b.Write(p.VCode)
 		sp = sp[1:]
 
 		if p.Size == 0 { // no length.

--- a/codec.go
+++ b/codec.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 )
 
-func stringToBytes(s string) ([]byte, error) {
+func stringToMultiaddr(s string) (multiaddr, error) {
 
 	// consume trailing slashes
 	s = strings.TrimRight(s, "/")
 
-	b := new(bytes.Buffer)
+	var b bytes.Buffer
 	sp := strings.Split(s, "/")
 
 	if sp[0] != "" {
-		return nil, fmt.Errorf("invalid multiaddr, must begin with /")
+		return "", fmt.Errorf("invalid multiaddr, must begin with /")
 	}
 
 	// consume first empty elem
@@ -24,7 +24,7 @@ func stringToBytes(s string) ([]byte, error) {
 	for len(sp) > 0 {
 		p := ProtocolWithName(sp[0])
 		if p.Code == 0 {
-			return nil, fmt.Errorf("no protocol with name %s", sp[0])
+			return "", fmt.Errorf("no protocol with name %s", sp[0])
 		}
 		b.Write(CodeToVarint(p.Code))
 		sp = sp[1:]
@@ -34,7 +34,7 @@ func stringToBytes(s string) ([]byte, error) {
 		}
 
 		if len(sp) < 1 {
-			return nil, fmt.Errorf("protocol requires address, none given: %s", p.Name)
+			return "", fmt.Errorf("protocol requires address, none given: %s", p.Name)
 		}
 
 		if p.Path {
@@ -44,17 +44,17 @@ func stringToBytes(s string) ([]byte, error) {
 		}
 
 		if p.Transcoder == nil {
-			return nil, fmt.Errorf("no transcoder for %s protocol", p.Name)
+			return "", fmt.Errorf("no transcoder for %s protocol", p.Name)
 		}
 		a, err := p.Transcoder.StringToBytes(sp[0])
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse %s: %s %s", p.Name, sp[0], err)
+			return "", fmt.Errorf("failed to parse %s: %s %s", p.Name, sp[0], err)
 		}
 		b.Write(a)
 		sp = sp[1:]
 	}
 
-	return b.Bytes(), nil
+	return multiaddr(b.Bytes()), nil
 }
 
 func validateBytes(b []byte) (err error) {
@@ -153,30 +153,4 @@ func sizeForAddr(p Protocol, b []byte) (int, error) {
 		}
 		return size + n, nil
 	}
-}
-
-func bytesSplit(b []byte) ([][]byte, error) {
-	var ret [][]byte
-	for len(b) > 0 {
-		code, n, err := ReadVarintCode(b)
-		if err != nil {
-			return nil, err
-		}
-
-		p := ProtocolWithCode(code)
-		if p.Code == 0 {
-			return nil, fmt.Errorf("no protocol with code %d", b[0])
-		}
-
-		size, err := sizeForAddr(p, b[n:])
-		if err != nil {
-			return nil, err
-		}
-
-		length := n + size
-		ret = append(ret, b[:length])
-		b = b[length:]
-	}
-
-	return ret, nil
 }

--- a/interface.go
+++ b/interface.go
@@ -20,13 +20,13 @@ type Multiaddr interface {
 	// Bytes returns the binary representation of this Multiaddr
 	Bytes() []byte
 
-	// Return the binary representation of this multiaddr as a string.
+	// Return the binary representation of this multiaddr as an immutable
+	// string.
 	//
-	// Doesn't allocate.
+	// Calling this function should be cheep, if not free.
 	ByteString() string
 
-	// String returns the string representation of this Multiaddr
-	// (may panic if internal state is corrupted)
+	// String returns the string representation of this Multiaddr.
 	String() string
 
 	// Protocols returns the list of Protocols this Multiaddr includes
@@ -41,7 +41,7 @@ type Multiaddr interface {
 
 	// Decapsultate removes a Multiaddr wrapping. For example:
 	//
-	//      /ip4/1.2.3.4/tcp/80 decapsulate /ip4/1.2.3.4 = /tcp/80
+	//      /ip4/1.2.3.4/tcp/80 decapsulate /tcp/80 = /ip4/1.2.3.4
 	//
 	Decapsulate(Multiaddr) Multiaddr
 

--- a/interface.go
+++ b/interface.go
@@ -17,8 +17,13 @@ type Multiaddr interface {
 	// Equal returns whether two Multiaddrs are exactly equal
 	Equal(Multiaddr) bool
 
-	// Bytes returns the []byte representation of this Multiaddr
+	// Bytes returns the binary representation of this Multiaddr
 	Bytes() []byte
+
+	// Return the binary representation of this multiaddr as a string.
+	//
+	// Doesn't allocate.
+	ByteString() string
 
 	// String returns the string representation of this Multiaddr
 	// (may panic if internal state is corrupted)

--- a/multiaddr.go
+++ b/multiaddr.go
@@ -1,18 +1,28 @@
+// Multiaddr is a cross-protocol, cross-platform format for representing
+// internet addresses. It emphasizes explicitness and self-description.
+// Learn more here: https://github.com/multiformats/multiaddr
+//
+// Multiaddrs have both a binary and string representation.
+//
+//     import ma "github.com/multiformats/go-multiaddr"
+//
+//     addr, err := ma.NewMultiaddr("/ip4/1.2.3.4/tcp/80")
+//     // err non-nil when parsing failed.
+//
+
 package multiaddr
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"strings"
 )
 
-// multiaddr is the data structure representing a Multiaddr
-type multiaddr struct {
-	bytes []byte
-}
+// Multiaddr is the data structure representing a Multiaddr
+// Multiaddrs are immutable and safe to use as map keys.
+type multiaddr string
 
-// NewMultiaddr parses and validates an input string, returning a *Multiaddr
+// NewMultiaddr parses and validates an input string, returning a Multiaddr
 func NewMultiaddr(s string) (a Multiaddr, err error) {
 	defer func() {
 		if e := recover(); e != nil {
@@ -20,11 +30,7 @@ func NewMultiaddr(s string) (a Multiaddr, err error) {
 			err = fmt.Errorf("%v", e)
 		}
 	}()
-	b, err := stringToBytes(s)
-	if err != nil {
-		return nil, err
-	}
-	return &multiaddr{bytes: b}, nil
+	return stringToMultiaddr(s)
 }
 
 // NewMultiaddrBytes initializes a Multiaddr from a byte representation.
@@ -41,36 +47,39 @@ func NewMultiaddrBytes(b []byte) (a Multiaddr, err error) {
 		return nil, err
 	}
 
-	return &multiaddr{bytes: b}, nil
+	return multiaddr(b), nil
 }
 
-// Equal tests whether two multiaddrs are equal
-func (m *multiaddr) Equal(m2 Multiaddr) bool {
-	return bytes.Equal(m.bytes, m2.Bytes())
+// Equal returns whether two Multiaddrs are exactly equal
+func (m multiaddr) Equal(o Multiaddr) bool {
+	return m.ByteString() == o.ByteString()
 }
 
 // Bytes returns the []byte representation of this Multiaddr
-func (m *multiaddr) Bytes() []byte {
-	// consider returning copy to prevent changing underneath us?
-	cpy := make([]byte, len(m.bytes))
-	copy(cpy, m.bytes)
-	return cpy
+func (m multiaddr) ByteString() string {
+	return string(m)
 }
 
-// String returns the string representation of a Multiaddr
-func (m *multiaddr) String() string {
-	s, err := bytesToString(m.bytes)
+// Bytes returns the []byte representation of this Multiaddr
+func (m multiaddr) Bytes() []byte {
+	return []byte(m)
+}
+
+// String returns the string representation of this Multiaddr
+// (may panic if internal state is corrupted)
+func (m multiaddr) String() string {
+	s, err := bytesToString(m.Bytes())
 	if err != nil {
 		panic("multiaddr failed to convert back to string. corrupted?")
 	}
 	return s
 }
 
-// Protocols returns the list of protocols this Multiaddr has.
-// will panic in case we access bytes incorrectly.
-func (m *multiaddr) Protocols() []Protocol {
+// Protocols returns the list of Protocols this Multiaddr includes
+// will panic if protocol code incorrect (and bytes accessed incorrectly)
+func (m multiaddr) Protocols() []Protocol {
 	ps := make([]Protocol, 0, 8)
-	b := m.bytes
+	b := m.Bytes()
 	for len(b) > 0 {
 		code, n, err := ReadVarintCode(b)
 		if err != nil {
@@ -96,27 +105,25 @@ func (m *multiaddr) Protocols() []Protocol {
 	return ps
 }
 
-// Encapsulate wraps a given Multiaddr, returning the resulting joined Multiaddr
-func (m *multiaddr) Encapsulate(o Multiaddr) Multiaddr {
-	mb := m.bytes
-	ob := o.Bytes()
-
-	b := make([]byte, len(mb)+len(ob))
-	copy(b, mb)
-	copy(b[len(mb):], ob)
-	return &multiaddr{bytes: b}
+// Encapsulate wraps this Multiaddr around another. For example:
+//
+//      /ip4/1.2.3.4 encapsulate /tcp/80 = /ip4/1.2.3.4/tcp/80
+//
+func (m multiaddr) Encapsulate(o Multiaddr) Multiaddr {
+	return multiaddr(m.ByteString() + o.ByteString())
 }
 
-// Decapsulate unwraps Multiaddr up until the given Multiaddr is found.
-func (m *multiaddr) Decapsulate(o Multiaddr) Multiaddr {
+// Decapsultate removes a Multiaddr wrapping. For example:
+//
+//      /ip4/1.2.3.4/tcp/80 decapsulate /ip4/1.2.3.4 = /tcp/80
+//
+func (m multiaddr) Decapsulate(o Multiaddr) Multiaddr {
 	s1 := m.String()
 	s2 := o.String()
 	i := strings.LastIndex(s1, s2)
 	if i < 0 {
-		// if multiaddr not contained, returns a copy.
-		cpy := make([]byte, len(m.bytes))
-		copy(cpy, m.bytes)
-		return &multiaddr{bytes: cpy}
+		// Immutable!
+		return o
 	}
 
 	ma, err := NewMultiaddr(s1[:i])
@@ -128,7 +135,8 @@ func (m *multiaddr) Decapsulate(o Multiaddr) Multiaddr {
 
 var ErrProtocolNotFound = fmt.Errorf("protocol not found in multiaddr")
 
-func (m *multiaddr) ValueForProtocol(code int) (string, error) {
+// ValueForProtocol returns the value (if any) following the specified protocol
+func (m multiaddr) ValueForProtocol(code int) (string, error) {
 	for _, sub := range Split(m) {
 		p := sub.Protocols()[0]
 		if p.Code == code {

--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -143,16 +143,16 @@ func TestStringToBytes(t *testing.T) {
 			t.Error("failed to decode hex", h)
 		}
 
-		b2, err := stringToBytes(s)
+		b2, err := stringToMultiaddr(s)
 		if err != nil {
 			t.Error("failed to convert", s)
 		}
 
-		if !bytes.Equal(b1, b2) {
+		if !bytes.Equal(b1, []byte(b2)) {
 			t.Error("failed to convert", s, "to", b1, "got", b2)
 		}
 
-		if err := validateBytes(b2); err != nil {
+		if err := validateBytes([]byte(b2)); err != nil {
 			t.Error(err)
 		}
 	}
@@ -170,7 +170,7 @@ func TestBytesToString(t *testing.T) {
 			t.Error("failed to decode hex", h)
 		}
 
-		if err := validateBytes(b); err != nil {
+		if err := validateBytes([]byte(b)); err != nil {
 			t.Error(err)
 		}
 
@@ -213,18 +213,6 @@ func TestBytesSplitAndJoin(t *testing.T) {
 		joined := Join(split...)
 		if !m.Equal(joined) {
 			t.Errorf("joined components failed: %s != %s", m, joined)
-		}
-
-		// modifying underlying bytes is fine.
-		m2 := m.(*multiaddr)
-		for i := range m2.bytes {
-			m2.bytes[i] = 0
-		}
-
-		for i, a := range split {
-			if a.String() != res[i] {
-				t.Errorf("split component failed: %s != %s", a, res[i])
-			}
 		}
 	}
 
@@ -418,5 +406,17 @@ func TestFuzzString(t *testing.T) {
 			_ = ma.String()
 			ma.Protocols()
 		}
+	}
+}
+
+func TestBinaryRepresentation(t *testing.T) {
+	expected := []byte{0x4, 0x7f, 0x0, 0x0, 0x1, 0x91, 0x2, 0x4, 0xd2}
+	ma, err := NewMultiaddr("/ip4/127.0.0.1/udp/1234")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !bytes.Equal(ma.Bytes(), expected) {
+		t.Errorf("expected %x, got %x", expected, ma.Bytes())
 	}
 }

--- a/protocols.go
+++ b/protocols.go
@@ -12,7 +12,7 @@ type Protocol struct {
 	Size       int // a size of -1 indicates a length-prefixed variable size
 	Name       string
 	VCode      []byte
-	Path       bool // indicates a path protocol (eg unix, http)
+	Path       bool // indicates a path protocol (eg unix)
 	Transcoder Transcoder
 }
 

--- a/util.go
+++ b/util.go
@@ -4,37 +4,41 @@ import "fmt"
 
 // Split returns the sub-address portions of a multiaddr.
 func Split(m Multiaddr) []Multiaddr {
-	split, err := bytesSplit(m.Bytes())
-	if err != nil {
-		panic(fmt.Errorf("invalid multiaddr %s", m.String()))
-	}
+	s := m.ByteString()
+	b := m.Bytes()
+	var addrs []Multiaddr
+	for len(b) > 0 {
+		code, n, err := ReadVarintCode(b)
+		if err != nil {
+			return nil
+		}
 
-	addrs := make([]Multiaddr, len(split))
-	for i, addr := range split {
-		addrs[i] = &multiaddr{bytes: addr}
+		p := ProtocolWithCode(code)
+		if p.Code == 0 {
+			panic(fmt.Errorf("invalid multiaddr %s, no protocol with code %d", m.String(), b[0]))
+		}
+
+		size, err := sizeForAddr(p, b[n:])
+		if err != nil {
+			panic(fmt.Errorf("invalid multiaddr %s: %s", m.String(), err))
+		}
+
+		length := n + size
+		addrs = append(addrs, multiaddr(s[:length]))
+		b = b[length:]
+		s = s[length:]
 	}
 	return addrs
 }
 
 // Join returns a combination of addresses.
 func Join(ms ...Multiaddr) Multiaddr {
-
-	length := 0
-	bs := make([][]byte, len(ms))
-	for i, m := range ms {
-		bs[i] = m.Bytes()
-		length += len(bs[i])
+	var ret string
+	for _, m := range ms {
+		ret += m.ByteString()
 	}
 
-	bidx := 0
-	b := make([]byte, length)
-	for _, mb := range bs {
-		for i := range mb {
-			b[bidx] = mb[i]
-			bidx++
-		}
-	}
-	return &multiaddr{bytes: b}
+	return multiaddr(ret)
 }
 
 // Cast re-casts a byte slice as a multiaddr. will panic if it fails to parse.
@@ -43,7 +47,7 @@ func Cast(b []byte) Multiaddr {
 	if err != nil {
 		panic(fmt.Errorf("multiaddr failed to parse: %s", err))
 	}
-	return &multiaddr{bytes: b}
+	return multiaddr(b)
 }
 
 // StringCast like Cast, but parses a string. Will also panic if it fails to parse.


### PR DESCRIPTION
1. This saves one level of indirection, one distinct allocation, and a few bytes.
2. This allows Multiaddrs to be used as map keys (we can use this to make our Peerstore more efficient).
3. Removing the interface allows us to serialize these without copying.

This commit isn't as efficient as it could be. We could improve it slightly by using unsafe casts to temporarily treat strings as bytes. However I'm not sure this will improve performance much and, in general, this change will lead to fewer allocations overall.