### PR TITLE
fully validate multiaddr byte representations on construction

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.7: QmUxSEGbv2nmYNnfXi7839wwQqTN3kwQeUxe8dTjZWZs7J
+1.3.0: QmYmsdtJ3HsodkePE3eU3TsCaP2YvPZJ4LoXnNkDE5Tpt7

--- a/codec.go
+++ b/codec.go
@@ -26,7 +26,7 @@ func stringToBytes(s string) ([]byte, error) {
 		if p.Code == 0 {
 			return nil, fmt.Errorf("no protocol with name %s", sp[0])
 		}
-		b.Write(CodeToVarint(p.Code))
+		_, _ = b.Write(CodeToVarint(p.Code))
 		sp = sp[1:]
 
 		if p.Size == 0 { // no length.
@@ -51,7 +51,7 @@ func stringToBytes(s string) ([]byte, error) {
 			return nil, fmt.Errorf("failed to parse %s: %s %s", p.Name, sp[0], err)
 		}
 		if p.Size < 0 { // varint size.
-			b.Write(CodeToVarint(len(a)))
+			_, _ = b.Write(CodeToVarint(len(a)))
 		}
 		b.Write(a)
 		sp = sp[1:]

--- a/codec.go
+++ b/codec.go
@@ -50,6 +50,9 @@ func stringToBytes(s string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse %s: %s %s", p.Name, sp[0], err)
 		}
+		if p.Size < 0 { // varint size.
+			b.Write(CodeToVarint(len(a)))
+		}
 		b.Write(a)
 		sp = sp[1:]
 	}
@@ -74,10 +77,12 @@ func validateBytes(b []byte) (err error) {
 			continue
 		}
 
-		size, err := sizeForAddr(p, b)
+		n, size, err := sizeForAddr(p, b)
 		if err != nil {
 			return err
 		}
+
+		b = b[n:]
 
 		if len(b) < size || size < 0 {
 			return fmt.Errorf("invalid value for size")
@@ -109,10 +114,12 @@ func bytesToString(b []byte) (ret string, err error) {
 			continue
 		}
 
-		size, err := sizeForAddr(p, b)
+		n, size, err := sizeForAddr(p, b)
 		if err != nil {
 			return "", err
 		}
+
+		b = b[n:]
 
 		if len(b) < size || size < 0 {
 			return "", fmt.Errorf("invalid value for size")
@@ -125,6 +132,9 @@ func bytesToString(b []byte) (ret string, err error) {
 		if err != nil {
 			return "", err
 		}
+		if p.Path && len(a) > 0 && a[0] == '/' {
+			a = a[1:]
+		}
 		if len(a) > 0 {
 			s += "/" + a
 		}
@@ -134,24 +144,24 @@ func bytesToString(b []byte) (ret string, err error) {
 	return s, nil
 }
 
-func sizeForAddr(p Protocol, b []byte) (int, error) {
+func sizeForAddr(p Protocol, b []byte) (skip, size int, err error) {
 	switch {
 	case p.Size > 0:
-		return (p.Size / 8), nil
+		return 0, (p.Size / 8), nil
 	case p.Size == 0:
-		return 0, nil
+		return 0, 0, nil
 	case p.Path:
 		size, n, err := ReadVarintCode(b)
 		if err != nil {
-			return 0, err
+			return 0, 0, err
 		}
-		return size + n, nil
+		return n, size, nil
 	default:
 		size, n, err := ReadVarintCode(b)
 		if err != nil {
-			return 0, err
+			return 0, 0, err
 		}
-		return size + n, nil
+		return n, size, nil
 	}
 }
 
@@ -168,12 +178,12 @@ func bytesSplit(b []byte) ([][]byte, error) {
 			return nil, fmt.Errorf("no protocol with code %d", b[0])
 		}
 
-		size, err := sizeForAddr(p, b[n:])
+		n2, size, err := sizeForAddr(p, b[n:])
 		if err != nil {
 			return nil, err
 		}
 
-		length := n + size
+		length := n + n2 + size
 		ret = append(ret, b[:length])
 		b = b[length:]
 	}

--- a/codec.go
+++ b/codec.go
@@ -88,6 +88,11 @@ func validateBytes(b []byte) (err error) {
 			return fmt.Errorf("invalid value for size")
 		}
 
+		err = p.Transcoder.ValidateBytes(b[:size])
+		if err != nil {
+			return err
+		}
+
 		b = b[size:]
 	}
 

--- a/multiaddr.go
+++ b/multiaddr.go
@@ -86,12 +86,12 @@ func (m *multiaddr) Protocols() []Protocol {
 		ps = append(ps, p)
 		b = b[n:]
 
-		size, err := sizeForAddr(p, b)
+		n, size, err := sizeForAddr(p, b)
 		if err != nil {
 			panic(err)
 		}
 
-		b = b[size:]
+		b = b[n+size:]
 	}
 	return ps
 }

--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -478,3 +478,17 @@ func TestIPFSvP2P(t *testing.T) {
 		}
 	}
 }
+
+func TestInvalidP2PAddr(t *testing.T) {
+	badAddr := "a503221221c05877cbae039d70a5e600ea02c6f9f2942439285c9e344e26f8d280c850fad6"
+	bts, err := hex.DecodeString(badAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ma, err := NewMultiaddrBytes(bts)
+	if err == nil {
+		t.Error("should have failed")
+		// Check for panic
+		_ = ma.String()
+	}
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "license": "MIT",
   "name": "go-multiaddr",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.7"
+  "version": "1.3.0"
 }
 

--- a/protocols.go
+++ b/protocols.go
@@ -3,8 +3,8 @@ package multiaddr
 import (
 	"encoding/binary"
 	"fmt"
-	"strings"
 	"math/bits"
+	"strings"
 )
 
 // Protocol is a Multiaddr protocol description structure.
@@ -170,7 +170,7 @@ func ProtocolsWithString(s string) ([]Protocol, error) {
 
 // CodeToVarint converts an integer to a varint-encoded []byte
 func CodeToVarint(num int) []byte {
-	buf := make([]byte, bits.Len(uint(num))/7 + 1)
+	buf := make([]byte, bits.Len(uint(num))/7+1)
 	n := binary.PutUvarint(buf, uint64(num))
 	return buf[:n]
 }

--- a/transcoders.go
+++ b/transcoders.go
@@ -3,7 +3,6 @@ package multiaddr
 import (
 	"encoding/base32"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -129,22 +128,10 @@ func p2pStB(s string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse p2p addr: %s %s", s, err)
 	}
-	size := CodeToVarint(len(m))
-	b := append(size, m...)
-	return b, nil
+	return m, nil
 }
 
 func p2pBtS(b []byte) (string, error) {
-	// the address is a varint-prefixed multihash string representation
-	size, n, err := ReadVarintCode(b)
-	if err != nil {
-		return "", err
-	}
-
-	b = b[n:]
-	if len(b) != size {
-		return "", errors.New("inconsistent lengths")
-	}
 	m, err := mh.Cast(b)
 	if err != nil {
 		return "", err
@@ -155,27 +142,9 @@ func p2pBtS(b []byte) (string, error) {
 var TranscoderUnix = NewTranscoderFromFunctions(unixStB, unixBtS)
 
 func unixStB(s string) ([]byte, error) {
-	// the address is the whole remaining string, prefixed by a varint len
-	size := CodeToVarint(len(s))
-	b := append(size, []byte(s)...)
-	return b, nil
+	return []byte(s), nil
 }
 
 func unixBtS(b []byte) (string, error) {
-	// the address is a varint len prefixed string
-	size, n, err := ReadVarintCode(b)
-	if err != nil {
-		return "", err
-	}
-
-	b = b[n:]
-	if len(b) != size {
-		return "", errors.New("inconsistent lengths")
-	}
-	if size == 0 {
-		return "", errors.New("invalid length")
-	}
-	s := string(b)
-	s = s[1:] // remove starting slash
-	return s, nil
+	return string(b), nil
 }


### PR DESCRIPTION
Given that we have to modify transcoders anyways, this patch also moves some
repetitive logic out of these transcoders into this library.