### PR TITLE
add a Component interface to multiaddrs

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -96,51 +96,55 @@ func validateBytes(b []byte) (err error) {
 	return nil
 }
 
+func readComponent(b []byte) (int, component, error) {
+	var offset int
+	code, n, err := ReadVarintCode(b)
+	if err != nil {
+		return 0, component{}, err
+	}
+	offset += n
+
+	p := ProtocolWithCode(code)
+	if p.Code == 0 {
+		return 0, component{}, fmt.Errorf("no protocol with code %d", code)
+	}
+
+	if p.Size == 0 {
+		return offset, component{
+			bytes:    b[:offset],
+			offset:   offset,
+			protocol: p,
+		}, nil
+	}
+
+	n, size, err := sizeForAddr(p, b[offset:])
+	if err != nil {
+		return 0, component{}, err
+	}
+
+	offset += n
+
+	if len(b[offset:]) < size || size < 0 {
+		return 0, component{}, fmt.Errorf("invalid value for size")
+	}
+
+	return offset + size, component{
+		bytes:    b[:offset+size],
+		protocol: p,
+		offset:   offset,
+	}, nil
+}
+
 func bytesToString(b []byte) (ret string, err error) {
 	s := ""
 
 	for len(b) > 0 {
-		code, n, err := ReadVarintCode(b)
+		n, c, err := readComponent(b)
 		if err != nil {
 			return "", err
 		}
-
 		b = b[n:]
-		p := ProtocolWithCode(code)
-		if p.Code == 0 {
-			return "", fmt.Errorf("no protocol with code %d", code)
-		}
-		s += "/" + p.Name
-
-		if p.Size == 0 {
-			continue
-		}
-
-		n, size, err := sizeForAddr(p, b)
-		if err != nil {
-			return "", err
-		}
-
-		b = b[n:]
-
-		if len(b) < size || size < 0 {
-			return "", fmt.Errorf("invalid value for size")
-		}
-
-		if p.Transcoder == nil {
-			return "", fmt.Errorf("no transcoder for %s protocol", p.Name)
-		}
-		a, err := p.Transcoder.BytesToString(b[:size])
-		if err != nil {
-			return "", err
-		}
-		if p.Path && len(a) > 0 && a[0] == '/' {
-			a = a[1:]
-		}
-		if len(a) > 0 {
-			s += "/" + a
-		}
-		b = b[size:]
+		s += c.String()
 	}
 
 	return s, nil

--- a/component.go
+++ b/component.go
@@ -1,0 +1,129 @@
+package multiaddr
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// component is a single multiaddr component.
+type component struct {
+	bytes    []byte
+	protocol Protocol
+	offset   int
+}
+
+func (c *component) Bytes() []byte {
+	return c.bytes
+}
+
+func (c *component) Equal(o Multiaddr) bool {
+	return bytes.Equal(c.bytes, o.Bytes())
+}
+
+func (c *component) Protocols() []Protocol {
+	return []Protocol{c.protocol}
+}
+
+func (c *component) Decapsulate(o Multiaddr) Multiaddr {
+	if c.Equal(o) {
+		return nil
+	}
+	return c
+}
+
+func (c *component) Encapsulate(o Multiaddr) Multiaddr {
+	m := multiaddr{bytes: c.bytes}
+	return m.Encapsulate(o)
+}
+
+func (c *component) ValueForProtocol(code int) (string, error) {
+	if c.protocol.Code != code {
+		return "", ErrProtocolNotFound
+	}
+	return c.Value(), nil
+}
+
+func (c *component) ForEach(cb func(c Component) bool) {
+	cb(c)
+}
+
+func (c *component) Protocol() Protocol {
+	return c.protocol
+}
+
+func (c *component) RawValue() []byte {
+	return c.bytes[c.offset:]
+}
+
+func (c *component) Value() string {
+	if c.protocol.Transcoder == nil {
+		return ""
+	}
+	value, err := c.protocol.Transcoder.BytesToString(c.bytes[c.offset:])
+	if err != nil {
+		// This component must have been checked.
+		panic(err)
+	}
+	return value
+}
+
+func (c *component) String() string {
+	str := "/" + c.protocol.Name
+
+	value := c.Value()
+	if len(value) == 0 {
+		return str
+	}
+
+	if !(c.protocol.Path && value[0] == '/') {
+		str += "/"
+	}
+
+	return str + value
+}
+
+// NewComponent constructs a new multiaddr component
+func NewComponent(protocol, value string) (Component, error) {
+	p := ProtocolWithName(protocol)
+	if p.Code == 0 {
+		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
+	}
+	if p.Transcoder != nil {
+		bts, err := p.Transcoder.StringToBytes(value)
+		if err != nil {
+			return nil, err
+		}
+		return newComponent(p, bts), nil
+	} else if value != "" {
+		return nil, fmt.Errorf("protocol %s doesn't take a value", p.Name)
+	}
+	return newComponent(p, nil), nil
+	// TODO: handle path /?
+}
+
+func newComponent(protocol Protocol, bvalue []byte) *component {
+	size := len(bvalue)
+	size += len(protocol.VCode)
+	if protocol.Size < 0 {
+		size += VarintSize(len(bvalue))
+	}
+	maddr := make([]byte, size)
+	var offset int
+	offset += copy(maddr[offset:], protocol.VCode)
+	if protocol.Size < 0 {
+		offset += binary.PutUvarint(maddr[offset:], uint64(len(bvalue)))
+	}
+	copy(maddr[offset:], bvalue)
+
+	// For debugging
+	if len(maddr) != offset+len(bvalue) {
+		panic("incorrect length")
+	}
+
+	return &component{
+		bytes:    maddr,
+		protocol: protocol,
+		offset:   offset,
+	}
+}

--- a/interface.go
+++ b/interface.go
@@ -43,5 +43,28 @@ type Multiaddr interface {
 	Decapsulate(Multiaddr) Multiaddr
 
 	// ValueForProtocol returns the value (if any) following the specified protocol
+	//
+	// Deprecated: protocols can appear multiple times in a single multiaddr
+	// so this method isn't particularly robust.
 	ValueForProtocol(code int) (string, error)
+
+	// ForEach walks over each component in this mulitaddr, stopping when
+	// the callback returns false.
+	ForEach(func(c Component) bool)
+}
+
+// Component is a single component of a multiaddr.
+type Component interface {
+	Multiaddr
+
+	// Protocol returns the component's protocol.
+	Protocol() Protocol
+
+	// Value returns this component's value, formatted as a string.
+	Value() string
+
+	// RawValue returns the raw (bytes) value of the component.
+	//
+	// This function may expose immutable, internal state. Do not modify.
+	RawValue() []byte
 }

--- a/multiaddr.go
+++ b/multiaddr.go
@@ -127,18 +127,17 @@ func (m multiaddr) Decapsulate(o Multiaddr) Multiaddr {
 
 var ErrProtocolNotFound = fmt.Errorf("protocol not found in multiaddr")
 
-func (m multiaddr) ValueForProtocol(code int) (string, error) {
-	for _, sub := range Split(m) {
-		p := sub.Protocols()[0]
-		if p.Code == code {
-			if p.Size == 0 {
-				return "", nil
-			}
-			return strings.SplitN(sub.String(), "/", 3)[2], nil
+func (m multiaddr) ValueForProtocol(code int) (value string, err error) {
+	err = ErrProtocolNotFound
+	m.ForEach(func(c Component) bool {
+		if c.Protocol().Code == code {
+			value = c.Value()
+			err = nil
+			return false
 		}
-	}
-
-	return "", ErrProtocolNotFound
+		return true
+	})
+	return
 }
 
 func (m multiaddr) ForEach(cb func(c Component) bool) {

--- a/multiaddr.go
+++ b/multiaddr.go
@@ -140,3 +140,17 @@ func (m multiaddr) ValueForProtocol(code int) (string, error) {
 
 	return "", ErrProtocolNotFound
 }
+
+func (m multiaddr) ForEach(cb func(c Component) bool) {
+	b := m.bytes
+	for len(b) > 0 {
+		n, c, err := readComponent(b)
+		if err != nil {
+			panic(err)
+		}
+		if !cb(&c) {
+			return
+		}
+		b = b[n:]
+	}
+}

--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -524,3 +524,16 @@ func TestZone(t *testing.T) {
 		t.Errorf("expected %s, got %s", ip6String, ma2.String())
 	}
 }
+
+func TestComponent(t *testing.T) {
+	ma := StringCast("/ip4/127.0.0.1/udp/123")
+	components := Components(ma)
+
+	if components[0].Value() != "127.0.0.1" {
+		t.Error("component 0 has an invalid value")
+	}
+
+	if components[1].Value() != "123" {
+		t.Error("component 0 has an invalid value")
+	}
+}


### PR DESCRIPTION
This adds a `Component` interface to multiaddrs and deprecates `ValueForProtocol`. It should make working with multiaddrs significantly less painful.


Eventually, I'd like to add different component and multiaddr types (like the `net.Addr` types). However, I'm going to do this step-by-step.