### PR TITLE
Use the original protocol name for address missing errors

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -22,7 +22,8 @@ func stringToBytes(s string) ([]byte, error) {
 	sp = sp[1:]
 
 	for len(sp) > 0 {
-		p := ProtocolWithName(sp[0])
+		name := sp[0]
+		p := ProtocolWithName(name)
 		if p.Code == 0 {
 			return nil, fmt.Errorf("no protocol with name %s", sp[0])
 		}
@@ -34,7 +35,7 @@ func stringToBytes(s string) ([]byte, error) {
 		}
 
 		if len(sp) < 1 {
-			return nil, fmt.Errorf("protocol requires address, none given: %s", p.Name)
+			return nil, fmt.Errorf("protocol requires address, none given: %s", name)
 		}
 
 		if p.Path {


### PR DESCRIPTION
Reduces confusion due to aliased protocol names.