### PR TITLE
Add dns and p2p-webrtc-direct protocols

### DIFF
--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -26,6 +26,7 @@ func TestConstructFails(t *testing.T) {
 		"/ip6zone",
 		"/ip6zone/",
 		"/ip6zone//ip6/fe80::1",
+		"/dns4/%protocol.ai",
 		"/udp",
 		"/tcp",
 		"/sctp",
@@ -68,6 +69,7 @@ func TestConstructFails(t *testing.T) {
 		"/ip4/127.0.0.1/p2p/tcp",
 		"/unix",
 		"/ip4/1.2.3.4/tcp/80/unix",
+		"/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct",
 	}
 
 	for _, a := range cases {
@@ -88,6 +90,9 @@ func TestConstructSucceeds(t *testing.T) {
 		"/ip6zone/x%y/ip6/fe80::1",
 		"/ip6zone/x%y/ip6/::",
 		"/ip6zone/x/ip6/fe80::1/udp/1234/quic",
+		"/dns4/protocol.ai",
+		"/dns6/protocol.ai",
+		"/dnsaddr/protocol.ai",
 		"/onion/timaq4ygg2iegci7:1234",
 		"/onion/timaq4ygg2iegci7:80/http",
 		"/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234",
@@ -127,6 +132,8 @@ func TestConstructSucceeds(t *testing.T) {
 		"/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
 		"/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
 		"/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+		"/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",
+		"/dnsaddr/protocol.ai/tcp/5001/https/p2p-webrtc-direct",
 	}
 
 	for _, a := range cases {
@@ -200,6 +207,7 @@ func TestStringToBytes(t *testing.T) {
 	testString("/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234", "bd03adadec040be047f9658668b11a504f3155001f231a37f54c4476c07fb4cc139ed7e30304d2")
 	testString("/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA",
 		"ca0383038d3fc8c976a86ae4e78ba378e75ec41bc9ab1542a9cb422581987e118f5cb0c024f3639d6ad9b3aff613672f07bfbbbfc2f920ef910534ecaa6ff9c03e0fa4872a764d2fce6d4cfc5a5a9800cd95944cc9ef0241f753fe71494a175f334b35682459acadc4076428ab49b5a83a49d2ea2366b06461e4a559b0111fa750e0de0c138a94d1231ed5979572ff53922905636221994bdabc44bd0c17fef11622b16432db3f193400af53cc61aa9bfc0c4c8d874b41a6e18732f0b60f5662ef1a89c80589dd8366c90bb58bb85ead56356aba2a244950ca170abbd01094539014f84bdd383e4a10e00cee63dfc3e809506e2d9b54edbdca1bace6eaa119e68573d30533791fba830f5d80be5c051a77c09415e3b8fe3139400848be5244b8ae96bb0c4a24f819cba0488f34985eac741d3359180bd72cafa1559e4c19f54ea8cedbb6a5afde4319396eb92aab340c60a50cc2284580cb3ad09017e8d9abc60269b3d8d687680bd86ce834412273d4f2e3bf68dd3d6fe87e2426ac658cd5c77fd5c0aa000000")
+	testString("/dnsaddr/protocol.ai", "380c2f70726f746f636f6c2e6169")
 }
 
 func TestBytesToString(t *testing.T) {
@@ -232,6 +240,7 @@ func TestBytesToString(t *testing.T) {
 	testString("/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234", "bd03adadec040be047f9658668b11a504f3155001f231a37f54c4476c07fb4cc139ed7e30304d2")
 	testString("/garlic64/jT~IyXaoauTni6N4517EG8mrFUKpy0IlgZh-EY9csMAk82Odatmzr~YTZy8Hv7u~wvkg75EFNOyqb~nAPg-khyp2TS~ObUz8WlqYAM2VlEzJ7wJB91P-cUlKF18zSzVoJFmsrcQHZCirSbWoOknS6iNmsGRh5KVZsBEfp1Dg3gwTipTRIx7Vl5Vy~1OSKQVjYiGZS9q8RL0MF~7xFiKxZDLbPxk0AK9TzGGqm~wMTI2HS0Gm4Ycy8LYPVmLvGonIBYndg2bJC7WLuF6tVjVquiokSVDKFwq70BCUU5AU-EvdOD5KEOAM7mPfw-gJUG4tm1TtvcobrObqoRnmhXPTBTN5H7qDD12AvlwFGnfAlBXjuP4xOUAISL5SRLiulrsMSiT4GcugSI80mF6sdB0zWRgL1yyvoVWeTBn1TqjO27alr95DGTluuSqrNAxgpQzCKEWAyzrQkBfo2avGAmmz2NaHaAvYbOg0QSJz1PLjv2jdPW~ofiQmrGWM1cd~1cCqAAAA",
 		"ca0383038d3fc8c976a86ae4e78ba378e75ec41bc9ab1542a9cb422581987e118f5cb0c024f3639d6ad9b3aff613672f07bfbbbfc2f920ef910534ecaa6ff9c03e0fa4872a764d2fce6d4cfc5a5a9800cd95944cc9ef0241f753fe71494a175f334b35682459acadc4076428ab49b5a83a49d2ea2366b06461e4a559b0111fa750e0de0c138a94d1231ed5979572ff53922905636221994bdabc44bd0c17fef11622b16432db3f193400af53cc61aa9bfc0c4c8d874b41a6e18732f0b60f5662ef1a89c80589dd8366c90bb58bb85ead56356aba2a244950ca170abbd01094539014f84bdd383e4a10e00cee63dfc3e809506e2d9b54edbdca1bace6eaa119e68573d30533791fba830f5d80be5c051a77c09415e3b8fe3139400848be5244b8ae96bb0c4a24f819cba0488f34985eac741d3359180bd72cafa1559e4c19f54ea8cedbb6a5afde4319396eb92aab340c60a50cc2284580cb3ad09017e8d9abc60269b3d8d687680bd86ce834412273d4f2e3bf68dd3d6fe87e2426ac658cd5c77fd5c0aa000000")
+	testString("/dnsaddr/protocol.ai", "380c2f70726f746f636f6c2e6169")
 }
 
 func TestBytesSplitAndJoin(t *testing.T) {

--- a/protocols.go
+++ b/protocols.go
@@ -6,24 +6,28 @@ package multiaddr
 // TODO: Use a single source of truth for all multicodecs instead of
 // distributing them like this...
 const (
-	P_IP4      = 0x0004
-	P_TCP      = 0x0006
-	P_UDP      = 0x0111
-	P_DCCP     = 0x0021
-	P_IP6      = 0x0029
-	P_IP6ZONE  = 0x002A
-	P_QUIC     = 0x01CC
-	P_SCTP     = 0x0084
-	P_UDT      = 0x012D
-	P_UTP      = 0x012E
-	P_UNIX     = 0x0190
-	P_P2P      = 0x01A5
-	P_IPFS     = 0x01A5 // alias for backwards compatability
-	P_HTTP     = 0x01E0
-	P_HTTPS    = 0x01BB
-	P_ONION    = 0x01BC // also for backwards compatibility
-	P_ONION3   = 0x01BD
-	P_GARLIC64 = 0x01CA
+	P_IP4               = 0x0004
+	P_TCP               = 0x0006
+	P_UDP               = 0x0111
+	P_DCCP              = 0x0021
+	P_IP6               = 0x0029
+	P_IP6ZONE           = 0x002A
+	P_DNS4              = 0x0036
+	P_DNS6              = 0x0037
+	P_DNSADDR           = 0x0038
+	P_QUIC              = 0x01CC
+	P_SCTP              = 0x0084
+	P_UDT               = 0x012D
+	P_UTP               = 0x012E
+	P_UNIX              = 0x0190
+	P_P2P               = 0x01A5
+	P_IPFS              = 0x01A5 // alias for backwards compatability
+	P_HTTP              = 0x01E0
+	P_HTTPS             = 0x01BB
+	P_ONION             = 0x01BC // also for backwards compatibility
+	P_ONION3            = 0x01BD
+	P_GARLIC64          = 0x01CA
+	P_P2P_WEBRTC_DIRECT = 0x0114
 )
 
 var (
@@ -74,6 +78,30 @@ var (
 		Size:       LengthPrefixedVarSize,
 		Path:       false,
 		Transcoder: TranscoderIP6Zone,
+	}
+	protoDNS4 = Protocol{
+		Name:       "dns4",
+		Code:       P_DNS4,
+		VCode:      CodeToVarint(P_DNS4),
+		Size:       LengthPrefixedVarSize,
+		Path:       true,
+		Transcoder: TranscoderDNS,
+	}
+	protoDNS6 = Protocol{
+		Name:       "dns6",
+		Code:       P_DNS6,
+		VCode:      CodeToVarint(P_DNS6),
+		Size:       LengthPrefixedVarSize,
+		Path:       true,
+		Transcoder: TranscoderDNS,
+	}
+	protoDNSADDR = Protocol{
+		Name:       "dnsaddr",
+		Code:       P_DNSADDR,
+		VCode:      CodeToVarint(P_DNSADDR),
+		Size:       LengthPrefixedVarSize,
+		Path:       true,
+		Transcoder: TranscoderDNS,
 	}
 	protoSCTP = Protocol{
 		Name:       "sctp",
@@ -143,6 +171,11 @@ var (
 		Path:       true,
 		Transcoder: TranscoderUnix,
 	}
+	protoP2P_WEBRTC_DIRECT = Protocol{
+		Name:  "p2p-webrtc-direct",
+		Code:  P_P2P_WEBRTC_DIRECT,
+		VCode: CodeToVarint(P_P2P_WEBRTC_DIRECT),
+	}
 )
 
 func init() {
@@ -153,6 +186,9 @@ func init() {
 		protoDCCP,
 		protoIP6,
 		protoIP6ZONE,
+		protoDNS4,
+		protoDNS6,
+		protoDNSADDR,
 		protoSCTP,
 		protoONION2,
 		protoONION3,
@@ -164,6 +200,7 @@ func init() {
 		protoHTTPS,
 		protoP2P,
 		protoUNIX,
+		protoP2P_WEBRTC_DIRECT,
 	} {
 		if err := AddProtocol(p); err != nil {
 			panic(err)

--- a/transcoders.go
+++ b/transcoders.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -103,6 +104,29 @@ func ip6BtS(b []byte) (string, error) {
 
 func ip4BtS(b []byte) (string, error) {
 	return net.IP(b).String(), nil
+}
+
+var TranscoderDNS = NewTranscoderFromFunctions(urlStB, urlBtS, nil)
+
+func urlStB(s string) ([]byte, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse dns addr: %s", err)
+	}
+	b, err := u.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal dns addr: %s", err)
+	}
+	return b, nil
+}
+
+func urlBtS(b []byte) (string, error) {
+	u := &url.URL{}
+	err := u.UnmarshalBinary(b)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal dns addr: %s", err)
+	}
+	return u.String(), nil
 }
 
 var TranscoderPort = NewTranscoderFromFunctions(portStB, portBtS, nil)


### PR DESCRIPTION
This PR ports the `dns` and `p2p-webrtc-direct` protocol from `js-multiaddr`. This is in preparation of adding the `WebRTCDirect` pattern to `whyrusleeping/mafmt`.