### PR TITLE
Add p2p-webrtc-direct protocol

### DIFF
--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -68,6 +68,7 @@ func TestConstructFails(t *testing.T) {
 		"/ip4/127.0.0.1/p2p/tcp",
 		"/unix",
 		"/ip4/1.2.3.4/tcp/80/unix",
+		"/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct",
 	}
 
 	for _, a := range cases {
@@ -127,6 +128,7 @@ func TestConstructSucceeds(t *testing.T) {
 		"/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
 		"/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
 		"/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+		"/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",
 	}
 
 	for _, a := range cases {

--- a/protocols.go
+++ b/protocols.go
@@ -6,24 +6,25 @@ package multiaddr
 // TODO: Use a single source of truth for all multicodecs instead of
 // distributing them like this...
 const (
-	P_IP4      = 0x0004
-	P_TCP      = 0x0006
-	P_UDP      = 0x0111
-	P_DCCP     = 0x0021
-	P_IP6      = 0x0029
-	P_IP6ZONE  = 0x002A
-	P_QUIC     = 0x01CC
-	P_SCTP     = 0x0084
-	P_UDT      = 0x012D
-	P_UTP      = 0x012E
-	P_UNIX     = 0x0190
-	P_P2P      = 0x01A5
-	P_IPFS     = 0x01A5 // alias for backwards compatability
-	P_HTTP     = 0x01E0
-	P_HTTPS    = 0x01BB
-	P_ONION    = 0x01BC // also for backwards compatibility
-	P_ONION3   = 0x01BD
-	P_GARLIC64 = 0x01CA
+	P_IP4               = 0x0004
+	P_TCP               = 0x0006
+	P_UDP               = 0x0111
+	P_DCCP              = 0x0021
+	P_IP6               = 0x0029
+	P_IP6ZONE           = 0x002A
+	P_QUIC              = 0x01CC
+	P_SCTP              = 0x0084
+	P_UDT               = 0x012D
+	P_UTP               = 0x012E
+	P_UNIX              = 0x0190
+	P_P2P               = 0x01A5
+	P_IPFS              = 0x01A5 // alias for backwards compatability
+	P_HTTP              = 0x01E0
+	P_HTTPS             = 0x01BB
+	P_ONION             = 0x01BC // also for backwards compatibility
+	P_ONION3            = 0x01BD
+	P_GARLIC64          = 0x01CA
+	P_P2P_WEBRTC_DIRECT = 0x0114
 )
 
 var (
@@ -143,6 +144,11 @@ var (
 		Path:       true,
 		Transcoder: TranscoderUnix,
 	}
+	protoP2P_WEBRTC_DIRECT = Protocol{
+		Name:  "p2p-webrtc-direct",
+		Code:  P_P2P_WEBRTC_DIRECT,
+		VCode: CodeToVarint(P_P2P_WEBRTC_DIRECT),
+	}
 )
 
 func init() {
@@ -164,6 +170,7 @@ func init() {
 		protoHTTPS,
 		protoP2P,
 		protoUNIX,
+		protoP2P_WEBRTC_DIRECT,
 	} {
 		if err := AddProtocol(p); err != nil {
 			panic(err)

--- a/transcoders.go
+++ b/transcoders.go
@@ -231,7 +231,7 @@ func garlic64StB(s string) ([]byte, error) {
 }
 
 func garlic64BtS(b []byte) (string, error) {
-    if len(b) < 386 {
+	if len(b) < 386 {
 		return "", fmt.Errorf("failed to validate garlic addr: %s not an i2p base64 address. len: %d\n", b, len(b))
 	}
 	addr := garlicBase64Encoding.EncodeToString(b)


### PR DESCRIPTION
This PR ports the `p2p-webrtc-direct` protocol from `js-multiaddr`. This is in preparation of adding the `WebRTCDirect` pattern to `whyrusleeping/mafmt`.