### PR TITLE
trivial: remove stale TODO

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -2,9 +2,6 @@ package multiaddr
 
 // You **MUST** register your multicodecs with
 // https://github.com/multiformats/multicodec before adding them here.
-//
-// TODO: Use a single source of truth for all multicodecs instead of
-// distributing them like this...
 const (
 	P_IP4               = 0x0004
 	P_TCP               = 0x0006


### PR DESCRIPTION
According to https://github.com/multiformats/go-multiaddr-dns/pull/11#discussion_r243259716, we are now ok decentralising protocol codes to their context-specific modules.