### PR TITLE
memoize string representation of multiaddrs

### DIFF
--- a/util.go
+++ b/util.go
@@ -77,7 +77,7 @@ func SplitFirst(m Multiaddr) (*Component, Multiaddr) {
 	if len(b) == n {
 		return &c, nil
 	}
-	return &c, &multiaddr{b[n:]}
+	return &c, &multiaddr{bytes: b[n:]}
 }
 
 // SplitLast returns the rest of the multiaddr and the last component.
@@ -109,7 +109,7 @@ func SplitLast(m Multiaddr) (Multiaddr, *Component) {
 				// Only one component
 				return nil, &c
 			}
-			return &multiaddr{b[:offset]}, &c
+			return &multiaddr{bytes: b[:offset]}, &c
 		}
 		offset += n
 	}
@@ -152,7 +152,7 @@ func SplitFunc(m Multiaddr, cb func(Component) bool) (Multiaddr, Multiaddr) {
 	case len(b):
 		return m, nil
 	default:
-		return &multiaddr{b[:offset]}, &multiaddr{b[offset:]}
+		return &multiaddr{bytes: b[:offset]}, &multiaddr{bytes: b[offset:]}
 	}
 }
 


### PR DESCRIPTION
Calculating the string representation of multiaddrs is costly; we can memoise it.

Here's the thing, though. multiaddrs are immutable and our Stringer functions are pure, so there no functional need to synchronise. I much have unguarded state and calculate the string twice, rather than synchronize on every access, but I don't think it's possible to pacify the Go race detector selectively.

In my benchmarks, `sync.Mutex` was 10x slower than `atomic.Value` which doesn't provide any atomicity actually (we can still calculate the string twice), but in terms of quietening the race detector, it's the cheapest option.

Cost of locking and unlocking a `sync.Mutex`:

```
BenchmarkMu-8   	100000000	        14.6 ns/op
```

Cost of storing a string once in an `atomic.Value`, and loading it N times:

```
BenchmarkAtomicValue-8   	2000000000	         1.32 ns/op
```

Baseline (calculating the string every time):

```
BenchmarkStringEverytime-8   	 1000000	      1760 ns/op
```