### PR TITLE
fix https://github.com/multiformats/go-multiaddr/issues/108

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -5,6 +5,9 @@ package multiaddr
 const (
 	P_IP4               = 0x0004
 	P_TCP               = 0x0006
+	P_DNS4              = 0x0036
+	P_DNS6              = 0x0037
+	P_DNSADDR           = 0x0038
 	P_UDP               = 0x0111
 	P_DCCP              = 0x0021
 	P_IP6               = 0x0029
@@ -43,6 +46,27 @@ var (
 		Size:       16,
 		Path:       false,
 		Transcoder: TranscoderPort,
+	}
+	protoDNS4 = Protocol{
+		Code:       P_DNS4,
+		Size:       LengthPrefixedVarSize,
+		Name:       "dns4",
+		VCode:      CodeToVarint(P_DNS4),
+		Transcoder: TranscoderDns,
+	}
+	protoDNS6 = Protocol{
+		Code:       P_DNS6,
+		Size:       LengthPrefixedVarSize,
+		Name:       "dns6",
+		VCode:      CodeToVarint(P_DNS6),
+		Transcoder: TranscoderDns,
+	}
+	protoDNSADDR = Protocol{
+		Code:       P_DNSADDR,
+		Size:       LengthPrefixedVarSize,
+		Name:       "dnsaddr",
+		VCode:      CodeToVarint(P_DNSADDR),
+		Transcoder: TranscoderDns,
 	}
 	protoUDP = Protocol{
 		Name:       "udp",
@@ -175,6 +199,9 @@ func init() {
 	for _, p := range []Protocol{
 		protoIP4,
 		protoTCP,
+		protoDNS4,
+		protoDNS6,
+		protoDNSADDR,
 		protoUDP,
 		protoDCCP,
 		protoIP6,

--- a/protocols.go
+++ b/protocols.go
@@ -11,6 +11,7 @@ const (
 	P_IP6ZONE           = 0x002A
 	P_QUIC              = 0x01CC
 	P_SCTP              = 0x0084
+	P_CIRCUIT           = 0x0122
 	P_UDT               = 0x012D
 	P_UTP               = 0x012E
 	P_UNIX              = 0x0190
@@ -81,6 +82,14 @@ var (
 		Size:       16,
 		Transcoder: TranscoderPort,
 	}
+
+	protoCIRCUIT = Protocol{
+		Code:  P_CIRCUIT,
+		Size:  0,
+		Name:  "p2p-circuit",
+		VCode: CodeToVarint(P_CIRCUIT),
+	}
+
 	protoONION2 = Protocol{
 		Name:       "onion",
 		Code:       P_ONION,
@@ -165,6 +174,7 @@ func init() {
 		protoIP6,
 		protoIP6ZONE,
 		protoSCTP,
+		protoCIRCUIT,
 		protoONION2,
 		protoONION3,
 		protoGARLIC64,

--- a/protocols.go
+++ b/protocols.go
@@ -24,6 +24,7 @@ const (
 	P_GARLIC64          = 0x01BE
 	P_GARLIC32          = 0x01BF
 	P_P2P_WEBRTC_DIRECT = 0x0114
+	P_WS                = 0x01DD
 )
 
 var (
@@ -163,6 +164,11 @@ var (
 		Code:  P_P2P_WEBRTC_DIRECT,
 		VCode: CodeToVarint(P_P2P_WEBRTC_DIRECT),
 	}
+	protoWS = Protocol{
+		Name:  "ws",
+		Code:  P_WS,
+		VCode: CodeToVarint(P_WS),
+	}
 )
 
 func init() {
@@ -187,6 +193,7 @@ func init() {
 		protoP2P,
 		protoUNIX,
 		protoP2P_WEBRTC_DIRECT,
+		protoWS,
 	} {
 		if err := AddProtocol(p); err != nil {
 			panic(err)

--- a/transcoders.go
+++ b/transcoders.go
@@ -317,3 +317,20 @@ func unixStB(s string) ([]byte, error) {
 func unixBtS(b []byte) (string, error) {
 	return string(b), nil
 }
+
+var TranscoderDns = NewTranscoderFromFunctions(dnsStB, dnsBtS, dnsVal)
+
+func dnsVal(b []byte) error {
+	if bytes.IndexByte(b, '/') >= 0 {
+		return fmt.Errorf("domain name %q contains a slash", string(b))
+	}
+	return nil
+}
+
+func dnsStB(s string) ([]byte, error) {
+	return []byte(s), nil
+}
+
+func dnsBtS(b []byte) (string, error) {
+	return string(b), nil
+}


### PR DESCRIPTION
1. move p2p-circuit protocol definitions(https://github.com/libp2p/go-libp2p-circuit/blob/master/transport.go#L13-L24)
2. move ws protocol definitions(https://github.com/libp2p/go-ws-transport/blob/ec8d1818a2e6edad2496410cbc554df6fe930ea2/websocket.go#L23)
3. move dns protocol definitions(https://github.com/multiformats/go-multiaddr-dns/blob/3974bf3f84c52825588fdcc0fd0e0aa7953ab5ff/dns.go#L11)

to fix https://github.com/multiformats/go-multiaddr/issues/108
