### PR TITLE
Validate bytes when parsing string

### DIFF
--- a/transcoders.go
+++ b/transcoders.go
@@ -14,8 +14,11 @@ import (
 )
 
 type Transcoder interface {
+	// Validates and encodes to bytes a multiaddr that's in the string representation.
 	StringToBytes(string) ([]byte, error)
+	// Validates and decodes to a string a multiaddr that's in the bytes representation.
 	BytesToString([]byte) (string, error)
+	// Validates bytes when parsing a multiaddr that's already in the bytes representation.
 	ValidateBytes([]byte) error
 }
 
@@ -62,6 +65,9 @@ func ip4StB(s string) ([]byte, error) {
 func ip6zoneStB(s string) ([]byte, error) {
 	if len(s) == 0 {
 		return nil, fmt.Errorf("empty ip6zone")
+	}
+	if strings.Contains(s, "/") {
+		return nil, fmt.Errorf("IPv6 zone ID contains '/': %s", s)
 	}
 	return []byte(s), nil
 }


### PR DESCRIPTION
If no validation is done, it can create invalid Multiaddr.
Probably there is an obvious reason for not doing it. So, if it is the case, I am sorry.
As an example, you can create an ip6zone Multiaddr from the following string: `ip6zone/`. However, if you validate it, it raises an error, because it contains `/` 