### PR TITLE
don't return leading / for unix values on Windows

### DIFF
--- a/transcoders.go
+++ b/transcoders.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -317,10 +318,21 @@ func p2pBtS(b []byte) (string, error) {
 var TranscoderUnix = NewTranscoderFromFunctions(unixStB, unixBtS, nil)
 
 func unixStB(s string) ([]byte, error) {
+	if runtime.GOOS == "windows" {
+		return []byte(strings.TrimLeft(s, "/")), nil
+	}
 	return []byte(s), nil
 }
 
 func unixBtS(b []byte) (string, error) {
+	if runtime.GOOS == "windows" {
+		if len(b) < 1 {
+			return "", nil
+		}
+		if b[0] == '/' {
+			return string(b[1:]), nil
+		}
+	}
 	return string(b), nil
 }
 


### PR DESCRIPTION
This changes Unix components to return a valid/native system path on Windows from their `.Value` method.

Consider a multiaddr constructed from `/unix/c:\Users\me\unix.socket`.

Currently, the value returned is `/c:\Users\me\unix.socket`. Which isn't very useful.
This change returns `c:\Users\me\unix.socket` instead, so that the path value may be passed directly from the multiaddr component to other system functions (within `os`, `net`, etc.).

I figured it made more sense for `component.Value()` to return a system native value from the source rather than expect users to parse the output and have special platform handling in their codebase. 
```go
multiaddr.ForEach(ma, func(comp multiaddr.Component) bool {
	if comp.Protocol().Code == multiaddr.P_UNIX {
		// assume multiaddr package will return a native value
		os.Remove(comp.Value())
...
```
vs
```go
multiaddr.ForEach(ma, func(comp multiaddr.Component) bool {
	if comp.Protocol().Code == multiaddr.P_UNIX {
		val := comp.Value()
		if runtime.GOOS == "windows" {
			val = strings.TrimLeft(val, "/"))
		}
		// more special cases would be needed here later
		os.Remove(val)
...
```