### PR TITLE
dep: add "codependencies" for handling version conflicts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/ipfs/go-cid v0.0.7
+	github.com/libp2p/go-maddr-filter v0.1.0
+	github.com/multiformats/go-multiaddr-net v0.2.0
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/multiformats/go-varint v0.0.6
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
+github.com/libp2p/go-maddr-filter v0.1.0 h1:4ACqZKw8AqiuJfwFGq1CYDFugfXTOos+qQ3DETkhtCE=
+github.com/libp2p/go-maddr-filter v0.1.0/go.mod h1:VzZhTXkMucEGGEOSKddrwGiOv0tUhgnKqNEmIAz/bPU=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771 h1:MHkK1uRtFbVqvAgvWxafZe54+5uBxLluGylDiKgdhwo=
@@ -11,6 +13,10 @@ github.com/multiformats/go-base32 v0.0.3 h1:tw5+NhuwaOjJCC5Pp82QuXbrmLzWg7uxlMFp
 github.com/multiformats/go-base32 v0.0.3/go.mod h1:pLiuGC8y0QR3Ue4Zug5UzK9LjgbkL8NSQj0zQ5Nz/AA=
 github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ89tUg4F4=
 github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
+github.com/multiformats/go-multiaddr v0.2.2/go.mod h1:NtfXiOtHvghW9KojvtySjH5y0u0xW5UouOmQQrn6a3Y=
+github.com/multiformats/go-multiaddr v0.3.0/go.mod h1:dF9kph9wfJ+3VLAaeBqo9Of8x4fJxp6ggJGteB8HQTI=
+github.com/multiformats/go-multiaddr-net v0.2.0 h1:MSXRGN0mFymt6B1yo/6BPnIRpLPEnKgQNvVfCX5VDJk=
+github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5rnK7YaOIEOPVDI9tsJbEA=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=

--- a/internal/codependencies/README.md
+++ b/internal/codependencies/README.md
@@ -2,6 +2,8 @@ This package allows us to depend on other modules, to _force_ these other
 modules to upgrade to some minimum version. This allows us to express "co
 dependency" requirements in cases where this module doesn't strictly speaking
 _depend_ on another module, but conflicts with some version of that module.
+We are using this here to depend on deprecated modules that have been
+merged into this package. 
 
 In practice, this means:
 

--- a/internal/codependencies/README.md
+++ b/internal/codependencies/README.md
@@ -1,0 +1,12 @@
+This package allows us to depend on other modules, to _force_ these other
+modules to upgrade to some minimum version. This allows us to express "co
+dependency" requirements in cases where this module doesn't strictly speaking
+_depend_ on another module, but conflicts with some version of that module.
+
+In practice, this means:
+
+1. Packages imported here _will not_ end up in the final binary as nothing
+   imports this package.
+2. Modules containing these packages will, unfortunately, be downloaded as
+   "dependencies" of this package.
+3. Anyone using this module will be forced to upgrade all co-dependencies.

--- a/internal/codependencies/codependencies.go
+++ b/internal/codependencies/codependencies.go
@@ -1,0 +1,10 @@
+package codependencies
+
+import (
+	// Packages imported into this package.
+
+	// go-multiaddr-net < 0.2.0 conflict with this package.
+	_ "github.com/multiformats/go-multiaddr-net"
+	// go-maddr-filter < 0.1.0 conflicts with this package.
+	_ "github.com/libp2p/go-maddr-filter"
+)


### PR DESCRIPTION
This patch adds a special, internal, "codependencies" package that allows us to specify minimum required versions for modules we don't directly depend on.

Problem: Updating go-multiaddr without updating go-multiaddr-net and/or go-maddr-filter can cause conflicting type issues.

Proposal: Add "dependencies" on these _modules_ (circular module dependencies are perfectly legal), but avoid actually importing any packages.

Downside:

* Anyone using this module will also have to download these deprecated modules.

Upside:

* After upgrading this module, all "codependencies" will automatically be upgraded to compatible versions.
* If unused, codependencies will _not_ end up bloating the binary size. This is because "usage" is computed at the import/package layer, while module version requirements are computed at the module layer.