### PR TITLE
Add TLS protocol

### DIFF
--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -140,7 +140,7 @@ func TestConstructSucceeds(t *testing.T) {
 		"/udp/1234/udt",
 		"/udp/1234/utp",
 		"/tcp/1234/http",
-		"/tcp/1234/http/tls",
+		"/tcp/1234/tls/http",
 		"/tcp/1234/https",
 		"/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
 		"/ipfs/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234",
@@ -169,7 +169,7 @@ func TestConstructSucceeds(t *testing.T) {
 		"/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",
 		"/ip4/127.0.0.1/tcp/127/ws",
 		"/ip4/127.0.0.1/tcp/127/ws",
-		"/ip4/127.0.0.1/tcp/127/ws/tls",
+		"/ip4/127.0.0.1/tcp/127/tls/ws",
 		"/ip4/127.0.0.1/tcp/127/wss",
 		"/ip4/127.0.0.1/tcp/127/wss",
 	}

--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -140,6 +140,7 @@ func TestConstructSucceeds(t *testing.T) {
 		"/udp/1234/udt",
 		"/udp/1234/utp",
 		"/tcp/1234/http",
+		"/tcp/1234/http/tls",
 		"/tcp/1234/https",
 		"/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
 		"/ipfs/k2k4r8oqamigqdo6o7hsbfwd45y70oyynp98usk7zmyfrzpqxh1pohl7/tcp/1234",
@@ -168,6 +169,7 @@ func TestConstructSucceeds(t *testing.T) {
 		"/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct",
 		"/ip4/127.0.0.1/tcp/127/ws",
 		"/ip4/127.0.0.1/tcp/127/ws",
+		"/ip4/127.0.0.1/tcp/127/ws/tls",
 		"/ip4/127.0.0.1/tcp/127/wss",
 		"/ip4/127.0.0.1/tcp/127/wss",
 	}
@@ -425,9 +427,10 @@ func assertValueForProto(t *testing.T, a Multiaddr, p int, exp string) {
 }
 
 func TestGetValue(t *testing.T) {
-	a := newMultiaddr(t, "/ip4/127.0.0.1/utp/tcp/5555/udp/1234/utp/ipfs/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
+	a := newMultiaddr(t, "/ip4/127.0.0.1/utp/tcp/5555/udp/1234/tls/utp/ipfs/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
 	assertValueForProto(t, a, P_IP4, "127.0.0.1")
 	assertValueForProto(t, a, P_UTP, "")
+	assertValueForProto(t, a, P_TLS, "")
 	assertValueForProto(t, a, P_TCP, "5555")
 	assertValueForProto(t, a, P_UDP, "1234")
 	assertValueForProto(t, a, P_IPFS, "QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP")
@@ -528,6 +531,7 @@ func TestRoundTrip(t *testing.T) {
 		"/unix/a/b/c/d",
 		"/ip6/::ffff:127.0.0.1/tcp/111",
 		"/ip4/127.0.0.1/tcp/123",
+		"/ip4/127.0.0.1/tcp/123/tls",
 		"/ip4/127.0.0.1/udp/123",
 		"/ip4/127.0.0.1/udp/123/ip6/::",
 		"/p2p/QmbHVEEepCi7rn7VL7Exxpd2Ci9NNB6ifvqwhsrbRMgQFP",
@@ -630,7 +634,7 @@ func TestZone(t *testing.T) {
 }
 
 func TestBinaryMarshaler(t *testing.T) {
-	addr := newMultiaddr(t, "/ip4/0.0.0.0/tcp/4001")
+	addr := newMultiaddr(t, "/ip4/0.0.0.0/tcp/4001/tls")
 	b, err := addr.MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
@@ -646,7 +650,7 @@ func TestBinaryMarshaler(t *testing.T) {
 }
 
 func TestTextMarshaler(t *testing.T) {
-	addr := newMultiaddr(t, "/ip4/0.0.0.0/tcp/4001")
+	addr := newMultiaddr(t, "/ip4/0.0.0.0/tcp/4001/tls")
 	b, err := addr.MarshalText()
 	if err != nil {
 		t.Fatal(err)
@@ -662,7 +666,7 @@ func TestTextMarshaler(t *testing.T) {
 }
 
 func TestJSONMarshaler(t *testing.T) {
-	addr := newMultiaddr(t, "/ip4/0.0.0.0/tcp/4001")
+	addr := newMultiaddr(t, "/ip4/0.0.0.0/tcp/4001/tls")
 	b, err := addr.MarshalJSON()
 	if err != nil {
 		t.Fatal(err)

--- a/protocols.go
+++ b/protocols.go
@@ -20,16 +20,17 @@ const (
 	P_UTP               = 0x012E
 	P_UNIX              = 0x0190
 	P_P2P               = 0x01A5
-	P_IPFS              = 0x01A5 // alias for backwards compatability
+	P_IPFS              = 0x01A5 // alias for backwards compatibility
 	P_HTTP              = 0x01E0
-	P_HTTPS             = 0x01BB
+	P_HTTPS             = 0x01BB // deprecated alias for /tls/http
 	P_ONION             = 0x01BC // also for backwards compatibility
 	P_ONION3            = 0x01BD
 	P_GARLIC64          = 0x01BE
 	P_GARLIC32          = 0x01BF
 	P_P2P_WEBRTC_DIRECT = 0x0114
+	P_TLS               = 0x01c0
 	P_WS                = 0x01DD
-	P_WSS               = 0x01DE
+	P_WSS               = 0x01DE // deprecated alias for /tls/ws
 )
 
 var (
@@ -197,6 +198,12 @@ var (
 		Code:  P_P2P_WEBRTC_DIRECT,
 		VCode: CodeToVarint(P_P2P_WEBRTC_DIRECT),
 	}
+	protoTLS = Protocol{
+		Name:  "tls",
+		Code:  P_TLS,
+		VCode: CodeToVarint(P_TLS),
+		Size:  0,
+	}
 	protoWS = Protocol{
 		Name:  "ws",
 		Code:  P_WS,
@@ -235,6 +242,7 @@ func init() {
 		protoP2P,
 		protoUNIX,
 		protoP2P_WEBRTC_DIRECT,
+		protoTLS,
 		protoWS,
 		protoWSS,
 	} {


### PR DESCRIPTION
Added TLS protocol. There are plenty of applications of TLS protocol not in the context of using it with `http` or `ws`(e.g. in `gPRC`), so it seems logical to add it. Code for it was taken from [multicodec](https://github.com/multiformats/multicodec) repo.

There is https://github.com/multiformats/multiaddr/pull/109 PR that suggests adding TLS protocol, mark `https` and `wss` protocols as deprecated and start using `/tls/http` and `/tls/ws` instead.