### PR TITLE
guard against nil {Local,Remote}Addr() return values

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -248,16 +248,16 @@ func (l *maListener) Accept() (Conn, error) {
 	var raddr ma.Multiaddr
 	// This block protects us in transports (i.e. unix sockets) that don't have
 	// remote addresses for inbound connections.
-	if nconn.RemoteAddr().String() != "" {
-		raddr, err = FromNetAddr(nconn.RemoteAddr())
+	if addr := nconn.RemoteAddr(); addr != nil && addr.String() != "" {
+		raddr, err = FromNetAddr(addr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert conn.RemoteAddr: %s", err)
 		}
 	}
 
 	var laddr ma.Multiaddr
-	if nconn.LocalAddr().String() != "" {
-		laddr, err = FromNetAddr(nconn.LocalAddr())
+	if addr := nconn.LocalAddr(); addr != nil && addr.String() != "" {
+		laddr, err = FromNetAddr(addr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert conn.LocalAddr: %s", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-ipfs/issues/8211. As discussed in https://github.com/ipfs/go-ipfs/issues/8211#issuecomment-867036960, I'm not sure why `LocalAddr()` of a `net.Conn` would ever return `nil`, but as evidenced by the stack trace, it can happen (maybe just on certain architectures).

Playing it safe, we can check that the value is not `nil` before using it.