### PR TITLE
remove wrong (and redundant) IsIpv6LinkLocal

### DIFF
--- a/net/ip.go
+++ b/net/ip.go
@@ -95,18 +95,6 @@ func IsIPUnspecified(m ma.Multiaddr) bool {
 	return net.IP(c.RawValue()).IsUnspecified()
 }
 
-// IsIpv6LinkLocal returns whether the addr uses a non-local ip link
-func IsIpv6LinkLocal(a ma.Multiaddr) bool {
-	split := ma.Split(a)
-	if len(split) < 1 {
-		return false
-	}
-	if IsIP6LinkLocal(split[0]) {
-		return false
-	}
-	return true
-}
-
 // If m matches [zone,ip6,...], return [ip6,...]
 // else if m matches [], [zone], or [zone,...], return nil
 // else return m

--- a/net/resolve.go
+++ b/net/resolve.go
@@ -74,7 +74,7 @@ func interfaceAddresses() ([]ma.Multiaddr, error) {
 
 	var out []ma.Multiaddr
 	for _, a := range maddrs {
-		if !IsIpv6LinkLocal(a) {
+		if IsIP6LinkLocal(a) {
 			continue
 		}
 		out = append(out, a)

--- a/net/resolve_test.go
+++ b/net/resolve_test.go
@@ -55,21 +55,3 @@ func TestResolvingAddrs(t *testing.T) {
 		t.Fatal("should have failed")
 	}
 }
-
-func TestAddrOverNonLocalIP(t *testing.T) {
-	bad := []ma.Multiaddr{
-		newMultiaddr(t, "/ip6/fe80::1/tcp/1234"),   // link local
-		newMultiaddr(t, "/ip6/fe80::100/tcp/1234"), // link local
-	}
-	good := []ma.Multiaddr{
-		newMultiaddr(t, "/ip4/127.0.0.1/tcp/1234"),
-		newMultiaddr(t, "/ip6/::1/tcp/1234"),
-		newMultiaddr(t, "/ip4/1.2.3.4/udp/1234/utp"),
-	}
-	for _, addr := range bad {
-		require.Falsef(t, IsIpv6LinkLocal(addr), "%s is a link local addr", addr)
-	}
-	for _, addr := range good {
-		require.Truef(t, IsIpv6LinkLocal(addr), "%s is not a link local addr", addr)
-	}
-}


### PR DESCRIPTION
Fixes #169.

We should just use `IsIP6LinkLocal` instead.