### PR TITLE
Add webrtc

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -36,7 +36,7 @@ const (
 	P_WS                = 0x01DD
 	P_WSS               = 0x01DE // deprecated alias for /tls/ws
 	P_PLAINTEXTV2       = 0x706c61
-	P_WEBRTC            = 0x115
+	P_WEBRTC            = 0x118
 )
 
 var (

--- a/protocols.go
+++ b/protocols.go
@@ -36,7 +36,7 @@ const (
 	P_WS                = 0x01DD
 	P_WSS               = 0x01DE // deprecated alias for /tls/ws
 	P_PLAINTEXTV2       = 0x706c61
-	P_XWEBRTC           = 0x115
+	P_WEBRTC           = 0x115
 )
 
 var (
@@ -249,11 +249,9 @@ var (
 		VCode: CodeToVarint(P_WSS),
 	}
 	protoXWebRTC = Protocol {
-		Name: "x-webrtc",
-		Code: P_XWEBRTC,
-		VCode: CodeToVarint(P_XWEBRTC),
-		Size: 256,
-		Transcoder: TranscoderXWebRTC,
+		Name: "webrtc",
+		Code: P_WEBRTC,
+		VCode: CodeToVarint(P_WEBRTC),
 	}
 )
 

--- a/protocols.go
+++ b/protocols.go
@@ -36,6 +36,7 @@ const (
 	P_WS                = 0x01DD
 	P_WSS               = 0x01DE // deprecated alias for /tls/ws
 	P_PLAINTEXTV2       = 0x706c61
+	P_XWEBRTC           = 0x115
 )
 
 var (
@@ -246,6 +247,13 @@ var (
 		Name:  "wss",
 		Code:  P_WSS,
 		VCode: CodeToVarint(P_WSS),
+	}
+	protoXWebRTC = Protocol {
+		Name: "x-webrtc",
+		Code: P_XWEBRTC,
+		VCode: CodeToVarint(P_XWEBRTC),
+		Size: 256,
+		Transcoder: TranscoderXWebRTC,
 	}
 )
 

--- a/protocols.go
+++ b/protocols.go
@@ -36,7 +36,7 @@ const (
 	P_WS                = 0x01DD
 	P_WSS               = 0x01DE // deprecated alias for /tls/ws
 	P_PLAINTEXTV2       = 0x706c61
-	P_WEBRTC           = 0x115
+	P_WEBRTC            = 0x115
 )
 
 var (
@@ -248,9 +248,9 @@ var (
 		Code:  P_WSS,
 		VCode: CodeToVarint(P_WSS),
 	}
-	protoWebRTC = Protocol {
-		Name: "webrtc",
-		Code: P_WEBRTC,
+	protoWebRTC = Protocol{
+		Name:  "webrtc",
+		Code:  P_WEBRTC,
 		VCode: CodeToVarint(P_WEBRTC),
 	}
 )

--- a/protocols.go
+++ b/protocols.go
@@ -248,7 +248,7 @@ var (
 		Code:  P_WSS,
 		VCode: CodeToVarint(P_WSS),
 	}
-	protoXWebRTC = Protocol {
+	protoWebRTC = Protocol {
 		Name: "webrtc",
 		Code: P_WEBRTC,
 		VCode: CodeToVarint(P_WEBRTC),
@@ -289,6 +289,7 @@ func init() {
 		protoWS,
 		protoWSS,
 		protoPlaintextV2,
+		protoWebRTC,
 	} {
 		if err := AddProtocol(p); err != nil {
 			panic(err)

--- a/transcoders.go
+++ b/transcoders.go
@@ -391,4 +391,3 @@ func certHashStB(s string) ([]byte, error) {
 func certHashBtS(b []byte) (string, error) {
 	return multibase.Encode(multibase.Base64url, b)
 }
-

--- a/transcoders.go
+++ b/transcoders.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base32"
 	"encoding/base64"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"net"
 	"strconv"
@@ -392,21 +391,4 @@ func certHashStB(s string) ([]byte, error) {
 func certHashBtS(b []byte) (string, error) {
 	return multibase.Encode(multibase.Base64url, b)
 }
-
-func xwebrtcVal(b []byte) error {
-	if len(b) != 32 {
-		return fmt.Errorf("fingerprint should be 32 bytes, found: %d", len(b))
-	}
-	return nil
-}
-
-func xwebrtcStB(s string) ([]byte, error) {
-	return hex.DecodeString(s)
-}
-
-func xwebrtcBtS(b []byte) (string, error) {
-	return hex.EncodeToString(b), nil
-}
-
-var TranscoderXWebRTC = NewTranscoderFromFunctions(xwebrtcStB, xwebrtcBtS, xwebrtcVal)
 

--- a/transcoders.go
+++ b/transcoders.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base32"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"strconv"
@@ -391,3 +392,21 @@ func certHashStB(s string) ([]byte, error) {
 func certHashBtS(b []byte) (string, error) {
 	return multibase.Encode(multibase.Base64url, b)
 }
+
+func xwebrtcVal(b []byte) error {
+	if len(b) != 32 {
+		return fmt.Errorf("fingerprint should be 32 bytes, found: %d", len(b))
+	}
+	return nil
+}
+
+func xwebrtcStB(s string) ([]byte, error) {
+	return hex.DecodeString(s)
+}
+
+func xwebrtcBtS(b []byte) (string, error) {
+	return hex.EncodeToString(b), nil
+}
+
+var TranscoderXWebRTC = NewTranscoderFromFunctions(xwebrtcStB, xwebrtcBtS, xwebrtcVal)
+


### PR DESCRIPTION
Adds an `x-webrtc` protocol which holds the 32 byte hex encoded DTLS fingerprint received by the server. This is based on https://github.com/melekes/rust-multiaddr/commit/c88f5f4cf1ad223fe4753f081a88d3ca31f44d63 and is for supporting the Go implementation of the spec described in https://github.com/libp2p/specs/pull/412 .