### PR TITLE
use decimal numbers for multicodecs

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -3,41 +3,41 @@ package multiaddr
 // You **MUST** register your multicodecs with
 // https://github.com/multiformats/multicodec before adding them here.
 const (
-	P_IP4               = 0x0004
-	P_TCP               = 0x0006
-	P_DNS               = 0x0035 // 4 or 6
-	P_DNS4              = 0x0036
-	P_DNS6              = 0x0037
-	P_DNSADDR           = 0x0038
-	P_UDP               = 0x0111
-	P_DCCP              = 0x0021
-	P_IP6               = 0x0029
-	P_IP6ZONE           = 0x002A
-	P_IPCIDR            = 0x002B
-	P_QUIC              = 0x01CC
-	P_WEBTRANSPORT      = 0x01D1
-	P_CERTHASH          = 0x01D2
-	P_SCTP              = 0x0084
-	P_CIRCUIT           = 0x0122
-	P_UDT               = 0x012D
-	P_UTP               = 0x012E
-	P_UNIX              = 0x0190
-	P_P2P               = 0x01A5
-	P_IPFS              = 0x01A5 // alias for backwards compatibility
-	P_HTTP              = 0x01E0
-	P_HTTPS             = 0x01BB // deprecated alias for /tls/http
-	P_ONION             = 0x01BC // also for backwards compatibility
-	P_ONION3            = 0x01BD
-	P_GARLIC64          = 0x01BE
-	P_GARLIC32          = 0x01BF
-	P_P2P_WEBRTC_DIRECT = 0x0114
-	P_TLS               = 0x01c0
-	P_SNI               = 0x01c1
-	P_NOISE             = 0x01c6
-	P_WS                = 0x01DD
-	P_WSS               = 0x01DE // deprecated alias for /tls/ws
-	P_PLAINTEXTV2       = 0x706c61
-	P_WEBRTC            = 0x118
+	P_IP4               = 4
+	P_TCP               = 6
+	P_DNS               = 53 // 4 or 6
+	P_DNS4              = 54
+	P_DNS6              = 55
+	P_DNSADDR           = 56
+	P_UDP               = 273
+	P_DCCP              = 33
+	P_IP6               = 41
+	P_IP6ZONE           = 42
+	P_IPCIDR            = 43
+	P_QUIC              = 460
+	P_WEBTRANSPORT      = 465
+	P_CERTHASH          = 466
+	P_SCTP              = 132
+	P_CIRCUIT           = 290
+	P_UDT               = 301
+	P_UTP               = 302
+	P_UNIX              = 400
+	P_P2P               = 421
+	P_IPFS              = P_P2P // alias for backwards compatibility
+	P_HTTP              = 480
+	P_HTTPS             = 443 // deprecated alias for /tls/http
+	P_ONION             = 444 // also for backwards compatibility
+	P_ONION3            = 445
+	P_GARLIC64          = 446
+	P_GARLIC32          = 447
+	P_P2P_WEBRTC_DIRECT = 276
+	P_TLS               = 448
+	P_SNI               = 449
+	P_NOISE             = 454
+	P_WS                = 477
+	P_WSS               = 478 // deprecated alias for /tls/ws
+	P_PLAINTEXTV2       = 7367777
+	P_WEBRTC            = 280
 )
 
 var (


### PR DESCRIPTION
The multicodec table uses decimal numbers. Every time we add a value here, we have to be extra careful to convert it to hexadecimal.

Please review really, really carefully. Getting these numbers wrong would be _bad_.