### PR TITLE
Add host header

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -24,6 +24,7 @@ const (
 	P_UNIX              = 400
 	P_P2P               = 421
 	P_IPFS              = P_P2P // alias for backwards compatibility
+	P_HOST_HEADER       = 481
 	P_HTTP              = 480
 	P_HTTPS             = 443 // deprecated alias for /tls/http
 	P_ONION             = 444 // also for backwards compatibility
@@ -193,6 +194,13 @@ var (
 		VCode:      CodeToVarint(P_CERTHASH),
 		Size:       LengthPrefixedVarSize,
 		Transcoder: TranscoderCertHash,
+	}
+	protoHOSTHEADER = Protocol{
+		Code:       P_HOST_HEADER,
+		Size:       LengthPrefixedVarSize,
+		Name:       "host-header",
+		VCode:      CodeToVarint(P_HOST_HEADER),
+		Transcoder: TranscoderDns,
 	}
 	protoHTTP = Protocol{
 		Name:  "http",

--- a/transcoders.go
+++ b/transcoders.go
@@ -391,3 +391,29 @@ func certHashStB(s string) ([]byte, error) {
 func certHashBtS(b []byte) (string, error) {
 	return multibase.Encode(multibase.Base64url, b)
 }
+
+var TranscoderHostHeader = NewTranscoderFromFunctions(hostHeaderStB, hostHeaderBtS, hostHeaderVal)
+
+func hostHeaderVal(b []byte) error {
+	s := string(b)
+	host, port, err := net.SplitHostPort(s)
+	if err != nil {
+		return fmt.Errorf("host %q is invalid %w", s, err)
+	}
+	if err := dnsVal([]byte(host)); err != nil {
+		return err
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil || p < 0 || p > 65535 {
+		return fmt.Errorf("port %q is not valid", port)
+	}
+	return nil
+}
+
+func hostHeaderStB(s string) ([]byte, error) {
+	return []byte(s), nil
+}
+
+func hostHeaderBtS(b []byte) (string, error) {
+	return string(b), nil
+}


### PR DESCRIPTION
* Add host-header protocol
* Add Host Header Transcoder, validating against HTTP [RFC 2616 § 14.23](https://www.rfc-editor.org/rfc/rfc2616#section-14.23)

MultiAddr code to be merged in multiformats/multiaddr#144

Relates to multiformats/multicodec#296 and libp2p/go-libp2p#1829

cc @MarcoPolo 