### PR TITLE
reduce allocations in net.ResolveUnspecifiedAddress

### DIFF
--- a/net/resolve_test.go
+++ b/net/resolve_test.go
@@ -1,6 +1,7 @@
 package manet
 
 import (
+	"math/rand"
 	"testing"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -53,5 +54,19 @@ func TestResolvingAddrs(t *testing.T) {
 	}
 	if _, err := ResolveUnspecifiedAddresses(ip4u, ip6i); err == nil {
 		t.Fatal("should have failed")
+	}
+}
+
+func BenchmarkResolveAddr(b *testing.B) {
+	b.ReportAllocs()
+	unspec := []ma.Multiaddr{
+		ma.StringCast("/ip4/0.0.0.0/tcp/1234"),
+	}
+
+	iface := []ma.Multiaddr{
+		ma.StringCast("/ip4/127.0.0.1"),
+	}
+	for i := 0; i < b.N; i++ {
+		ResolveUnspecifiedAddress(unspec[rand.Intn(len(unspec))], iface)
 	}
 }

--- a/util.go
+++ b/util.go
@@ -27,16 +27,14 @@ func Join(ms ...Multiaddr) Multiaddr {
 	}
 
 	length := 0
-	bs := make([][]byte, len(ms))
-	for i, m := range ms {
-		bs[i] = m.Bytes()
-		length += len(bs[i])
+	for _, m := range ms {
+		length += len(m.Bytes())
 	}
 
 	bidx := 0
 	b := make([]byte, length)
-	for _, mb := range bs {
-		bidx += copy(b[bidx:], mb)
+	for _, m := range ms {
+		bidx += copy(b[bidx:], m.Bytes())
 	}
 	return &multiaddr{bytes: b}
 }


### PR DESCRIPTION
On the benchmark it reduces allocations from 10 allocs/op to 5 allocs/op. The benefits are greater if you have multiple interface addresses. 

