### PR TITLE
fix: sha256-simd: update to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,9 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
-	github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771 // indirect
+	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mr-tron/base58 v1.1.3 // indirect
 	github.com/multiformats/go-base32 v0.0.3 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,13 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
+github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
+github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
-github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771 h1:MHkK1uRtFbVqvAgvWxafZe54+5uBxLluGylDiKgdhwo=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
+github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
+github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.3 h1:v+sk57XuaCKGXpWtVBX8YJzO7hMGx4Aajh4TQbdEFdc=
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
@@ -37,6 +40,7 @@ golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N0
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Update sha256-simd to fix a test failure on Go 1.21.

```
=== RUN   TestInvalidP2PAddrString
runtime: g27: frame.sp=0xc00006bc50 top=0xc00006bfe0
	stack=[0xc00006b000-0xc00006c000
fatal error: traceback did not unwind completely

runtime stack:
runtime.throw({0x6909af?, 0x0?})
	/repos/golang/src/runtime/panic.go:1077 +0x5c fp=0x7ffcaa26a3e8 sp=0x7ffcaa26a3b8 pc=0x438f7c
runtime.(*unwinder).finishInternal(0x0?)
	/repos/golang/src/runtime/traceback.go:561 +0x12a fp=0x7ffcaa26a428 sp=0x7ffcaa26a3e8 pc=0x45f94a
runtime.(*unwinder).next(0x7ffcaa26a628?)
	/repos/golang/src/runtime/traceback.go:442 +0x232 fp=0x7ffcaa26a4a0 sp=0x7ffcaa26a428 pc=0x45f752
runtime.copystack(0xc0000d49c0, 0x800000002?)
	/repos/golang/src/runtime/stack.go:934 +0x2d2 fp=0x7ffcaa26a798 sp=0x7ffcaa26a4a0 pc=0x453052
runtime.newstack()
	/repos/golang/src/runtime/stack.go:1116 +0x47f fp=0x7ffcaa26a948 sp=0x7ffcaa26a798 pc=0x4535ff
runtime.morestack()
	/repos/golang/src/runtime/asm_amd64.s:593 +0x8f fp=0x7ffcaa26a950 sp=0x7ffcaa26a948 pc=0x46c6cf

goroutine 27 [copystack]:
github.com/minio/sha256-simd.blockAvx2({0xc00006bc88, 0x8, 0x8}, {0xc00006bd10, 0x40, 0x40})
	/home/paralin/go/pkg/mod/github.com/minio/sha256-simd@v0.1.1-0.20190913151208-6de447530771/sha256blockAvx2_amd64.s:125 +0x1423 fp=0xc00006bc58 sp=0xc00006bc50 pc=0x5d1b43
created by testing.(*T).Run in goroutine 1
	/repos/golang/src/testing/testing.go:1648 +0x3ad

goroutine 1 [chan receive]:
runtime.gopark(0xc0000f99e8?, 0x40eba5?, 0xb0?, 0x33?, 0x18?)
	/repos/golang/src/runtime/proc.go:398 +0xce fp=0xc0000f9980 sp=0xc0000f9960 pc=0x43be6e
runtime.chanrecv(0xc000024f50, 0xc0000f9a67, 0x1)
	/repos/golang/src/runtime/chan.go:583 +0x3cd fp=0xc0000f99f8 sp=0xc0000f9980 pc=0x40826d
runtime.chanrecv1(0x8828c0?, 0x637e40?)
	/repos/golang/src/runtime/chan.go:442 +0x12 fp=0xc0000f9a20 sp=0xc0000f99f8 pc=0x407e72
testing.(*T).Run(0xc0000d4680, {0x68bbbf?, 0x4ee17c?}, 0x6b59b0)
	/repos/golang/src/testing/testing.go:1649 +0x3c8 fp=0xc0000f9ae0 sp=0xc0000f9a20 pc=0x4ef268
testing.runTests.func1(0x883760?)
	/repos/golang/src/testing/testing.go:2054 +0x3e fp=0xc0000f9b30 sp=0xc0000f9ae0 pc=0x4f137e
testing.tRunner(0xc0000d4680, 0xc0000f9c48)
	/repos/golang/src/testing/testing.go:1595 +0xff fp=0xc0000f9b80 sp=0xc0000f9b30 pc=0x4ee43f
testing.runTests(0xc00009cc80?, {0x87dd40, 0x21, 0x21}, {0x414b9f?, 0xc0000f9d08?, 0x882e80?})
	/repos/golang/src/testing/testing.go:2052 +0x445 fp=0xc0000f9c78 sp=0xc0000f9b80 pc=0x4f1265
testing.(*M).Run(0xc00009cc80)
	/repos/golang/src/testing/testing.go:1925 +0x636 fp=0xc0000f9ec0 sp=0xc0000f9c78 pc=0x4efc56
main.main()
	_testmain.go:117 +0x19c fp=0xc0000f9f40 sp=0xc0000f9ec0 pc=0x61f8dc
runtime.main()
	/repos/golang/src/runtime/proc.go:267 +0x2bb fp=0xc0000f9fe0 sp=0xc0000f9f40 pc=0x43b9fb
runtime.goexit()
	/repos/golang/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0000f9fe8 sp=0xc0000f9fe0 pc=0x46e561

goroutine 2 [force gc (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/repos/golang/src/runtime/proc.go:398 +0xce fp=0xc000056fa8 sp=0xc000056f88 pc=0x43be6e
runtime.goparkunlock(...)
	/repos/golang/src/runtime/proc.go:404
runtime.forcegchelper()
	/repos/golang/src/runtime/proc.go:322 +0xb3 fp=0xc000056fe0 sp=0xc000056fa8 pc=0x43bcd3
runtime.goexit()
	/repos/golang/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000056fe8 sp=0xc000056fe0 pc=0x46e561
created by runtime.init.6 in goroutine 1
	/repos/golang/src/runtime/proc.go:310 +0x1a

goroutine 3 [GC sweep wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/repos/golang/src/runtime/proc.go:398 +0xce fp=0xc000057778 sp=0xc000057758 pc=0x43be6e
runtime.goparkunlock(...)
	/repos/golang/src/runtime/proc.go:404
runtime.bgsweep(0x0?)
	/repos/golang/src/runtime/mgcsweep.go:280 +0x94 fp=0xc0000577c8 sp=0xc000057778 pc=0x4262f4
runtime.gcenable.func1()
	/repos/golang/src/runtime/mgc.go:200 +0x25 fp=0xc0000577e0 sp=0xc0000577c8 pc=0x41b425
runtime.goexit()
	/repos/golang/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0000577e8 sp=0xc0000577e0 pc=0x46e561
created by runtime.gcenable in goroutine 1
	/repos/golang/src/runtime/mgc.go:200 +0x66

goroutine 4 [GC scavenge wait]:
runtime.gopark(0xc000024070?, 0x6f2550?, 0x1?, 0x0?, 0xc0000071e0?)
	/repos/golang/src/runtime/proc.go:398 +0xce fp=0xc000057f70 sp=0xc000057f50 pc=0x43be6e
runtime.goparkunlock(...)
	/repos/golang/src/runtime/proc.go:404
runtime.(*scavengerState).park(0x882f00)
	/repos/golang/src/runtime/mgcscavenge.go:425 +0x49 fp=0xc000057fa0 sp=0xc000057f70 pc=0x423b29
runtime.bgscavenge(0x0?)
	/repos/golang/src/runtime/mgcscavenge.go:653 +0x3c fp=0xc000057fc8 sp=0xc000057fa0 pc=0x4240bc
runtime.gcenable.func2()
	/repos/golang/src/runtime/mgc.go:201 +0x25 fp=0xc000057fe0 sp=0xc000057fc8 pc=0x41b3c5
runtime.goexit()
	/repos/golang/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000057fe8 sp=0xc000057fe0 pc=0x46e561
created by runtime.gcenable in goroutine 1
	/repos/golang/src/runtime/mgc.go:201 +0xa5

goroutine 5 [finalizer wait]:
runtime.gopark(0x6828e0?, 0x10043d001?, 0x0?, 0x0?, 0x444025?)
	/repos/golang/src/runtime/proc.go:398 +0xce fp=0xc000056628 sp=0xc000056608 pc=0x43be6e
runtime.runfinq()
	/repos/golang/src/runtime/mfinal.go:193 +0x107 fp=0xc0000567e0 sp=0xc000056628 pc=0x41a4a7
runtime.goexit()
	/repos/golang/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc0000567e8 sp=0xc0000567e0 pc=0x46e561
created by runtime.createfing in goroutine 1
	/repos/golang/src/runtime/mfinal.go:163 +0x3d
exit status 2
FAIL	github.com/multiformats/go-multiaddr	0.005s

```