### PR TITLE
net: consider /dns/localhost as private address

### DIFF
--- a/net/private.go
+++ b/net/private.go
@@ -113,18 +113,18 @@ func IsPublicAddr(a ma.Multiaddr) bool {
 		case ma.P_DNS, ma.P_DNS4, ma.P_DNS6, ma.P_DNSADDR:
 			dnsAddr := c.Value()
 			isPublic = true
-			if isSubDomain(dnsAddr, localHostDomain) {
+			if isSubdomain(dnsAddr, localHostDomain) {
 				isPublic = false
 				return false
 			}
 			for _, ud := range unResolvableDomains {
-				if isSubDomain(dnsAddr, ud) {
+				if isSubdomain(dnsAddr, ud) {
 					isPublic = false
 					return false
 				}
 			}
 			for _, pd := range privateUseDomains {
-				if isSubDomain(dnsAddr, pd) {
+				if isSubdomain(dnsAddr, pd) {
 					isPublic = false
 					break
 				}
@@ -135,10 +135,10 @@ func IsPublicAddr(a ma.Multiaddr) bool {
 	return isPublic
 }
 
-// isSubDomain checks if child is sub domain of parent. It also returns true if child and parent are
+// isSubdomain checks if child is sub domain of parent. It also returns true if child and parent are
 // the same domain.
 // Parent must have a "." prefix.
-func isSubDomain(child, parent string) bool {
+func isSubdomain(child, parent string) bool {
 	return strings.HasSuffix(child, parent) || child == parent[1:]
 }
 
@@ -155,7 +155,7 @@ func IsPrivateAddr(a ma.Multiaddr) bool {
 			isPrivate = inAddrRange(net.IP(c.RawValue()), Private6)
 		case ma.P_DNS, ma.P_DNS4, ma.P_DNS6, ma.P_DNSADDR:
 			dnsAddr := c.Value()
-			if isSubDomain(dnsAddr, localHostDomain) {
+			if isSubdomain(dnsAddr, localHostDomain) {
 				isPrivate = true
 			}
 			// We don't check for privateUseDomains because private use domains can

--- a/net/private.go
+++ b/net/private.go
@@ -69,12 +69,13 @@ var privateUseDomains = []string{
 	// MDNS
 	".local",
 
-	// RFC 6761: Users may assume that IPv4 and IPv6 address queries for localhost names will
-	// always resolve to the respective IP loopback address
-	".localhost",
 	// RFC 6761: No central authority for .test names
 	".test",
 }
+
+// RFC 6761: Users may assume that IPv4 and IPv6 address queries for localhost names will
+// always resolve to the respective IP loopback address
+const localHostDomain = ".localhost"
 
 func init() {
 	Private4 = parseCIDR(privateCIDR4)
@@ -112,14 +113,18 @@ func IsPublicAddr(a ma.Multiaddr) bool {
 		case ma.P_DNS, ma.P_DNS4, ma.P_DNS6, ma.P_DNSADDR:
 			dnsAddr := c.Value()
 			isPublic = true
+			if isSubDomain(dnsAddr, localHostDomain) {
+				isPublic = false
+				return false
+			}
 			for _, ud := range unResolvableDomains {
-				if strings.HasSuffix(dnsAddr, ud) {
+				if isSubDomain(dnsAddr, ud) {
 					isPublic = false
 					return false
 				}
 			}
 			for _, pd := range privateUseDomains {
-				if strings.HasSuffix(dnsAddr, pd) {
+				if isSubDomain(dnsAddr, pd) {
 					isPublic = false
 					break
 				}
@@ -128,6 +133,13 @@ func IsPublicAddr(a ma.Multiaddr) bool {
 		return false
 	})
 	return isPublic
+}
+
+// isSubDomain checks if child is sub domain of parent. It also returns true if child and parent are
+// the same domain.
+// Parent must have a "." prefix.
+func isSubDomain(child, parent string) bool {
+	return strings.HasSuffix(child, parent) || child == parent[1:]
 }
 
 // IsPrivateAddr returns true if the IP part of the mutiaddr is in a private network
@@ -141,6 +153,13 @@ func IsPrivateAddr(a ma.Multiaddr) bool {
 			isPrivate = inAddrRange(net.IP(c.RawValue()), Private4)
 		case ma.P_IP6:
 			isPrivate = inAddrRange(net.IP(c.RawValue()), Private6)
+		case ma.P_DNS, ma.P_DNS4, ma.P_DNS6, ma.P_DNSADDR:
+			dnsAddr := c.Value()
+			if isSubDomain(dnsAddr, localHostDomain) {
+				isPrivate = true
+			}
+			// We don't check for privateUseDomains because private use domains can
+			// resolve to public IP addresses
 		}
 		return false
 	})

--- a/net/private_test.go
+++ b/net/private_test.go
@@ -43,6 +43,16 @@ func TestIsPublicAddr(t *testing.T) {
 			isPublic:  false,
 			isPrivate: false, // You can configure .local domains in local networks to return public addrs
 		},
+		{
+			addr:      ma.StringCast("/dns/localhost/udp/1/quic-v1"),
+			isPublic:  false,
+			isPrivate: true,
+		},
+		{
+			addr:      ma.StringCast("/dns/a.localhost/tcp/1"),
+			isPublic:  false,
+			isPrivate: true,
+		},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
This fixes IsPrivateAddr check to correctly classify localhost dns addresses as private. 

This fixes sub domain check to correctly classify equal domains as sub domains. So /dns/localhost/ is classified as non public. This is similar to https://pkg.go.dev/github.com/miekg/dns#IsSubDomain. I didn't want to import a library for this so I'm using a custom implementation. 
