### PR TITLE
Small fixes to parsing ports

### DIFF
--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -83,6 +83,7 @@ func TestConstructFails(t *testing.T) {
 		"/ip4/127.0.0.1/p2p/tcp",
 		"/unix",
 		"/ip4/1.2.3.4/tcp/80/unix",
+		"/ip4/1.2.3.4/tcp/-1/unix",
 		"/ip4/127.0.0.1/tcp/9090/http/p2p-webcrt-direct",
 		"/",
 		"",

--- a/transcoders.go
+++ b/transcoders.go
@@ -132,12 +132,9 @@ func ip4BtS(b []byte) (string, error) {
 var TranscoderPort = NewTranscoderFromFunctions(portStB, portBtS, nil)
 
 func portStB(s string) ([]byte, error) {
-	i, err := strconv.Atoi(s)
+	i, err := strconv.ParseUint(s, 10, 16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse port addr: %s", err)
-	}
-	if i >= 65536 {
-		return nil, fmt.Errorf("failed to parse port addr: %s", "greater than 65536")
 	}
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, uint16(i))
@@ -146,7 +143,7 @@ func portStB(s string) ([]byte, error) {
 
 func portBtS(b []byte) (string, error) {
 	i := binary.BigEndian.Uint16(b)
-	return strconv.Itoa(int(i)), nil
+	return strconv.FormatUint(uint64(i), 10), nil
 }
 
 var TranscoderOnion = NewTranscoderFromFunctions(onionStB, onionBtS, nil)
@@ -167,12 +164,9 @@ func onionStB(s string) ([]byte, error) {
 	}
 
 	// onion port number
-	i, err := strconv.Atoi(addr[1])
+	i, err := strconv.ParseUint(addr[1], 10, 16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse onion addr: %s", err)
-	}
-	if i >= 65536 {
-		return nil, fmt.Errorf("failed to parse onion addr: %s", "port greater than 65536")
 	}
 	if i < 1 {
 		return nil, fmt.Errorf("failed to parse onion addr: %s", "port less than 1")
@@ -189,7 +183,10 @@ func onionStB(s string) ([]byte, error) {
 func onionBtS(b []byte) (string, error) {
 	addr := strings.ToLower(base32.StdEncoding.EncodeToString(b[0:10]))
 	port := binary.BigEndian.Uint16(b[10:12])
-	return addr + ":" + strconv.Itoa(int(port)), nil
+	if port < 1 {
+		return "", fmt.Errorf("failed to parse onion addr: %s", "port less than 1")
+	}
+	return addr + ":" + strconv.FormatUint(uint64(port), 10), nil
 }
 
 var TranscoderOnion3 = NewTranscoderFromFunctions(onion3StB, onion3BtS, nil)
@@ -210,12 +207,9 @@ func onion3StB(s string) ([]byte, error) {
 	}
 
 	// onion port number
-	i, err := strconv.Atoi(addr[1])
+	i, err := strconv.ParseUint(addr[1], 10, 16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse onion addr: %s", err)
-	}
-	if i >= 65536 {
-		return nil, fmt.Errorf("failed to parse onion addr: %s", "port greater than 65536")
 	}
 	if i < 1 {
 		return nil, fmt.Errorf("failed to parse onion addr: %s", "port less than 1")
@@ -232,7 +226,10 @@ func onion3StB(s string) ([]byte, error) {
 func onion3BtS(b []byte) (string, error) {
 	addr := strings.ToLower(base32.StdEncoding.EncodeToString(b[0:35]))
 	port := binary.BigEndian.Uint16(b[35:37])
-	str := addr + ":" + strconv.Itoa(int(port))
+	if port < 1 {
+		return "", fmt.Errorf("failed to parse onion addr: %s", "port less than 1")
+	}
+	str := addr + ":" + strconv.FormatUint(uint64(port), 10)
 	return str, nil
 }
 

--- a/transcoders.go
+++ b/transcoders.go
@@ -168,8 +168,8 @@ func onionStB(s string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse onion addr: %s", err)
 	}
-	if i < 1 {
-		return nil, fmt.Errorf("failed to parse onion addr: %s", "port less than 1")
+	if i == 0 {
+		return nil, fmt.Errorf("failed to parse onion addr: %s", "non-zero port")
 	}
 
 	onionPortBytes := make([]byte, 2)
@@ -183,8 +183,8 @@ func onionStB(s string) ([]byte, error) {
 func onionBtS(b []byte) (string, error) {
 	addr := strings.ToLower(base32.StdEncoding.EncodeToString(b[0:10]))
 	port := binary.BigEndian.Uint16(b[10:12])
-	if port < 1 {
-		return "", fmt.Errorf("failed to parse onion addr: %s", "port less than 1")
+	if port == 0 {
+		return "", fmt.Errorf("failed to parse onion addr: %s", "non-zero port")
 	}
 	return addr + ":" + strconv.FormatUint(uint64(port), 10), nil
 }
@@ -211,8 +211,8 @@ func onion3StB(s string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse onion addr: %s", err)
 	}
-	if i < 1 {
-		return nil, fmt.Errorf("failed to parse onion addr: %s", "port less than 1")
+	if i == 0 {
+		return nil, fmt.Errorf("failed to parse onion addr: %s", "non-zero port")
 	}
 
 	onionPortBytes := make([]byte, 2)


### PR DESCRIPTION
### What type of PR is this?

Bug fix 

### What does this PR address?

This PR addresses some inconsistencies in the parsing of ports in various formats.

1. No longer allows negative integer port values to be silently converted to uints 
2. Remove incorrect error string for max uint16 values. (Previously the wrong value for a MAX_UINT16 was logged)
3. Replace AtoI and ItoA strcov calls with ParseUint and FormatUint
4. Add test for negative udp/tcp ports

### Potential Changes

I elected to replace the AtoI and ItoA with the parse/format uints with base16. These require less checks at the cost of less robust errors. If this seems like too big of a trade off I can reformat it back to the old way while still maintaining the bug fixes.