### PR TITLE
Redundant nil checks

### DIFF
--- a/net/ip.go
+++ b/net/ip.go
@@ -114,6 +114,9 @@ func zoneless(m ma.Multiaddr) ma.Multiaddr {
 			return nil
 		}
 		tailhead, _ := ma.SplitFirst(tail)
+		if tailhead == nil {
+			return nil
+		}
 		if tailhead.Protocol().Code != ma.P_IP6 {
 			return nil
 		}

--- a/net/resolve.go
+++ b/net/resolve.go
@@ -12,6 +12,9 @@ import (
 func ResolveUnspecifiedAddress(resolve ma.Multiaddr, ifaceAddrs []ma.Multiaddr) ([]ma.Multiaddr, error) {
 	// split address into its components
 	first, rest := ma.SplitFirst(resolve)
+	if first == nil {
+		return nil, fmt.Errorf("invalid address components: %s", resolve)
+	}
 
 	// if first component (ip) is not unspecified, use it as is.
 	if !IsIPUnspecified(first) {
@@ -22,6 +25,9 @@ func ResolveUnspecifiedAddress(resolve ma.Multiaddr, ifaceAddrs []ma.Multiaddr) 
 	out := make([]ma.Multiaddr, 0, len(ifaceAddrs))
 	for _, ia := range ifaceAddrs {
 		iafirst, _ := ma.SplitFirst(ia)
+		if iafirst == nil {
+			return nil, fmt.Errorf("invalid interface component: %s", ia)
+		}
 		// must match the first protocol to be resolve.
 		if iafirst.Protocol().Code != resolveProto {
 			continue

--- a/net/resolve.go
+++ b/net/resolve.go
@@ -28,7 +28,7 @@ func ResolveUnspecifiedAddress(resolve ma.Multiaddr, ifaceAddrs []ma.Multiaddr) 
 		if iafirst == nil {
 			return nil, fmt.Errorf("invalid interface component: %s", ia)
 		}
-		// must match the first protocol to be resolve.
+		// must match the first protocol to be resolved.
 		if iafirst.Protocol().Code != resolveProto {
 			continue
 		}


### PR DESCRIPTION
### What type of PR is this?

Robustness + typo

### What does this PR address?

Disclaimer: I have not found cases where proper library usage could trigger a panic on these functions. 

This PR does two things.

1. places additional nil checks on some of the SplitFirst calls. It adds a negligible performance cost to protect against improper usage in callers as well as protecting against panics caused by bugs in multiaddr parsing. 
2. fix typo in comments