### PR TITLE
return err on empty multiaddr

### DIFF
--- a/multiaddr.go
+++ b/multiaddr.go
@@ -27,6 +27,10 @@ func NewMultiaddr(s string) (a Multiaddr, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(b) == 0 {
+		return nil, fmt.Errorf("empty multiaddr")
+	}
+
 	return &multiaddr{bytes: b}, nil
 }
 


### PR DESCRIPTION
### What type of PR is this?

Bug fix

### What does this PR address?

This PR addresses an issue where the validation for the string and bytes constructors behave differently. validateBytes() checks that the multiaddr is not empty and returns an error if so. The string constructor does not which can lead an empty multiaddress with no error that will cause a panic when operated on.