### PR TITLE
net: restrict unicast ip6 public address space

### DIFF
--- a/net/ip.go
+++ b/net/ip.go
@@ -123,20 +123,10 @@ func zoneless(m ma.Multiaddr) ma.Multiaddr {
 	}
 }
 
-var nat64WellKnownPrefix net.IPNet
-
-func init() {
-	_, np, err := net.ParseCIDR("64:ff9b::/96")
-	if err != nil {
-		panic(err)
-	}
-	nat64WellKnownPrefix = *np
-}
-
 // IsNAT64IPv4ConvertedIPv6Addr returns whether addr is a well-known prefix "64:ff9b::/96" addr
 // used for NAT64 Translation. See RFC 6052
 func IsNAT64IPv4ConvertedIPv6Addr(addr ma.Multiaddr) bool {
 	c, _ := ma.SplitFirst(addr)
 	return c != nil && c.Protocol().Code == ma.P_IP6 &&
-		nat64WellKnownPrefix.Contains(net.IP(c.RawValue()))
+		inAddrRange(c.RawValue(), nat64)
 }

--- a/net/ip_test.go
+++ b/net/ip_test.go
@@ -38,6 +38,11 @@ func TestIsWellKnownPrefixIPv4ConvertedIPv6Address(t *testing.T) {
 			want:          false,
 			failureReason: "64:ff9b::1 is not well-known prefix",
 		},
+		{
+			addr:          ma.StringCast("/ip6/64:ff9b:1::1:192.0.1.2/tcp/1234"),
+			want:          true,
+			failureReason: "64:ff9b:1::1 is allowed for NAT64 translation",
+		},
 	}
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/net/private_test.go
+++ b/net/private_test.go
@@ -53,6 +53,21 @@ func TestIsPublicAddr(t *testing.T) {
 			isPublic:  false,
 			isPrivate: true,
 		},
+		{
+			addr:      ma.StringCast("/ip6/2400::1/tcp/10"),
+			isPublic:  true,
+			isPrivate: false,
+		},
+		{
+			addr:      ma.StringCast("/ip6/2001:db8::42/tcp/10"),
+			isPublic:  false,
+			isPrivate: false,
+		},
+		{
+			addr:      ma.StringCast("/ip6/64:ff9b::1.1.1.1/tcp/10"),
+			isPublic:  true,
+			isPrivate: false,
+		},
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
Global Unicast IPv6 addresses only belong to prefix 2000::/3. This change also classifies NAT64 prefixes as Public Addresses as they may reference public IPv4 addresses.