### PR TITLE
.Decapsulate by Components

### DIFF
--- a/multiaddr.go
+++ b/multiaddr.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"golang.org/x/exp/slices"
 )
@@ -150,26 +149,46 @@ func (m *multiaddr) Encapsulate(o Multiaddr) Multiaddr {
 }
 
 // Decapsulate unwraps Multiaddr up until the given Multiaddr is found.
-func (m *multiaddr) Decapsulate(o Multiaddr) Multiaddr {
-	s1 := m.String()
-	s2 := o.String()
-	i := strings.LastIndex(s1, s2)
-	if i < 0 {
+func (m *multiaddr) Decapsulate(right Multiaddr) Multiaddr {
+	if right == nil {
+		return m
+	}
+
+	leftParts := Split(m)
+	rightParts := Split(right)
+
+	lastIndex := -1
+	for i := range leftParts {
+		foundMatch := false
+		for j, rightC := range rightParts {
+			if len(leftParts) <= i+j {
+				foundMatch = false
+				break
+			}
+
+			foundMatch = rightC.Equal(leftParts[i+j])
+			if !foundMatch {
+				break
+			}
+		}
+
+		if foundMatch {
+			lastIndex = i
+		}
+	}
+
+	if lastIndex == 0 {
+		return nil
+	}
+
+	if lastIndex < 0 {
 		// if multiaddr not contained, returns a copy.
 		cpy := make([]byte, len(m.bytes))
 		copy(cpy, m.bytes)
 		return &multiaddr{bytes: cpy}
 	}
 
-	if i == 0 {
-		return nil
-	}
-
-	ma, err := NewMultiaddr(s1[:i])
-	if err != nil {
-		panic("Multiaddr.Decapsulate incorrect byte boundaries.")
-	}
-	return ma
+	return Join(leftParts[:lastIndex]...)
 }
 
 var ErrProtocolNotFound = fmt.Errorf("protocol not found in multiaddr")


### PR DESCRIPTION
We have the concept of multiaddr components. We should use that instead of trying to split things by strings.