### PR TITLE
feat: add tinygo support

### DIFF
--- a/net/convert.go
+++ b/net/convert.go
@@ -79,26 +79,6 @@ func MultiaddrToIPNet(m ma.Multiaddr) (*net.IPNet, error) {
 	return ipnet, err
 }
 
-func parseBasicNetMaddr(maddr ma.Multiaddr) (net.Addr, error) {
-	network, host, err := DialArgs(maddr)
-	if err != nil {
-		return nil, err
-	}
-
-	switch network {
-	case "tcp", "tcp4", "tcp6":
-		return net.ResolveTCPAddr(network, host)
-	case "udp", "udp4", "udp6":
-		return net.ResolveUDPAddr(network, host)
-	case "ip", "ip4", "ip6":
-		return net.ResolveIPAddr(network, host)
-	case "unix":
-		return net.ResolveUnixAddr(network, host)
-	}
-
-	return nil, fmt.Errorf("network not supported: %s", network)
-}
-
 func FromIPAndZone(ip net.IP, zone string) (ma.Multiaddr, error) {
 	switch {
 	case ip.To4() != nil:

--- a/net/net_other.go
+++ b/net/net_other.go
@@ -1,0 +1,76 @@
+//go:build !tinygo
+
+package manet
+
+import (
+	"fmt"
+	"net"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func parseBasicNetMaddr(maddr ma.Multiaddr) (net.Addr, error) {
+	network, host, err := DialArgs(maddr)
+	if err != nil {
+		return nil, err
+	}
+
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		return net.ResolveTCPAddr(network, host)
+	case "udp", "udp4", "udp6":
+		return net.ResolveUDPAddr(network, host)
+	case "ip", "ip4", "ip6":
+		return net.ResolveIPAddr(network, host)
+	case "unix":
+		return net.ResolveUnixAddr(network, host)
+	}
+
+	return nil, fmt.Errorf("network not supported: %s", network)
+}
+
+func wrap(nconn net.Conn, laddr, raddr ma.Multiaddr) Conn {
+	endpts := maEndpoints{
+		laddr: laddr,
+		raddr: raddr,
+	}
+	// This sucks. However, it's the only way to reliably expose the
+	// underlying methods. This way, users that need access to, e.g.,
+	// CloseRead and CloseWrite, can do so via type assertions.
+	switch nconn := nconn.(type) {
+	case *net.TCPConn:
+		return &struct {
+			*net.TCPConn
+			maEndpoints
+		}{nconn, endpts}
+	case *net.UDPConn:
+		return &struct {
+			*net.UDPConn
+			maEndpoints
+		}{nconn, endpts}
+	case *net.IPConn:
+		return &struct {
+			*net.IPConn
+			maEndpoints
+		}{nconn, endpts}
+	case *net.UnixConn:
+		return &struct {
+			*net.UnixConn
+			maEndpoints
+		}{nconn, endpts}
+	case halfOpen:
+		return &struct {
+			halfOpen
+			maEndpoints
+		}{nconn, endpts}
+	default:
+		return &struct {
+			net.Conn
+			maEndpoints
+		}{nconn, endpts}
+	}
+}
+
+func listenPacket(network, address string) (net.PacketConn, error) {
+	return net.ListenPacket(network, address)
+}

--- a/net/net_tinygo.go
+++ b/net/net_tinygo.go
@@ -1,0 +1,84 @@
+//go:build tinygo
+
+package manet
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+func parseBasicNetMaddr(maddr ma.Multiaddr) (net.Addr, error) {
+	network, host, err := DialArgs(maddr)
+	if err != nil {
+		return nil, err
+	}
+
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		return net.ResolveTCPAddr(network, host)
+	case "udp", "udp4", "udp6":
+		return net.ResolveUDPAddr(network, host)
+		/*
+			https://github.com/tinygo-org/net/issues/23
+			case "ip", "ip4", "ip6":
+					return net.ResolveIPAddr(network, host)
+			case "unix":
+					return net.ResolveUnixAddr(network, host)
+		*/
+	}
+
+	return nil, fmt.Errorf("network not supported: %s", network)
+}
+
+func wrap(nconn net.Conn, laddr, raddr ma.Multiaddr) Conn {
+	endpts := maEndpoints{
+		laddr: laddr,
+		raddr: raddr,
+	}
+	// This sucks. However, it's the only way to reliably expose the
+	// underlying methods. This way, users that need access to, e.g.,
+	// CloseRead and CloseWrite, can do so via type assertions.
+	switch nconn := nconn.(type) {
+	case *net.TCPConn:
+		return &struct {
+			*net.TCPConn
+			maEndpoints
+		}{nconn, endpts}
+	case *net.UDPConn:
+		return &struct {
+			*net.UDPConn
+			maEndpoints
+		}{nconn, endpts}
+		/*
+			case *net.IPConn:
+				return &struct {
+					*net.IPConn
+					maEndpoints
+				}{nconn, endpts}
+		*/
+		/*
+			case *net.UnixConn:
+					return &struct {
+						*net.UnixConn
+						maEndpoints
+					}{nconn, endpts}
+		*/
+	case halfOpen:
+		return &struct {
+			halfOpen
+			maEndpoints
+		}{nconn, endpts}
+	default:
+		return &struct {
+			net.Conn
+			maEndpoints
+		}{nconn, endpts}
+	}
+}
+
+func listenPacket(network, address string) (net.PacketConn, error) {
+	return nil, errors.New("tinygo: net.ListenPacket is not implemented")
+}


### PR DESCRIPTION
Add a separate build-tagged file for tinygo and not-tinygo (other).

Stub functions not available in tinygo.

Fixes build with:

tinygo build -tags "tinygo purego" -target wasm -no-debug -opt=2 ./