### PR TITLE
android 11+ issue permission

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -11,6 +11,7 @@ import (
 	"net"
 
 	ma "github.com/multiformats/go-multiaddr"
+	anet "github.com/wlynxg/anet"
 )
 
 // Conn is the equivalent of a net.Conn object. It is the
@@ -387,7 +388,7 @@ func WrapPacketConn(pc net.PacketConn) (PacketConn, error) {
 
 // InterfaceMultiaddrs will return the addresses matching net.InterfaceAddrs
 func InterfaceMultiaddrs() ([]ma.Multiaddr, error) {
-	addrs, err := net.InterfaceAddrs()
+	addrs, err := anet.InterfaceAddrs()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix for failed to resolve local interface addresses	{"error": "route ip+net: netlinkrib: permission denied"} in android 11+