### PR TITLE
Faster megular expressions

### DIFF
--- a/util.go
+++ b/util.go
@@ -129,6 +129,6 @@ func ForEach(m Multiaddr, cb func(c Component) bool) {
 }
 
 func (m Multiaddr) Match(p ...meg.Pattern) (bool, error) {
-	s := meg.PatternToMatchState(p...)
-	return meg.Match(s, m)
+	matcher := meg.PatternToMatchState(p...)
+	return meg.Match(matcher, m)
 }

--- a/util.go
+++ b/util.go
@@ -129,6 +129,6 @@ func ForEach(m Multiaddr, cb func(c Component) bool) {
 }
 
 func (m Multiaddr) Match(p ...meg.Pattern) (bool, error) {
-	matcher := meg.PatternToMatchState(p...)
+	matcher := meg.PatternToMatcher(p...)
 	return meg.Match(matcher, m)
 }

--- a/x/meg/bench_test.go
+++ b/x/meg/bench_test.go
@@ -1,0 +1,344 @@
+package meg_test
+
+import (
+	"testing"
+
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr/x/meg"
+)
+
+type preallocatedCapture struct {
+	certHashes []string
+	matcher    meg.Matcher
+}
+
+func preallocateCapture() *preallocatedCapture {
+	p := &preallocatedCapture{}
+	p.matcher = meg.PatternToMatchState(
+		meg.Or(
+			meg.Val(multiaddr.P_IP4),
+			meg.Val(multiaddr.P_IP6),
+			meg.Val(multiaddr.P_DNS),
+		),
+		meg.Val(multiaddr.P_UDP),
+		meg.Val(multiaddr.P_WEBRTC_DIRECT),
+		meg.CaptureZeroOrMore(multiaddr.P_CERTHASH, &p.certHashes),
+	)
+	return p
+}
+
+var webrtcMatchPrealloc *preallocatedCapture
+
+func (p *preallocatedCapture) IsWebRTCDirectMultiaddr(addr multiaddr.Multiaddr) (bool, int) {
+	found, _ := meg.Match(p.matcher, addr)
+	return found, len(p.certHashes)
+}
+
+// IsWebRTCDirectMultiaddr returns whether addr is a /webrtc-direct multiaddr with the count of certhashes
+// in addr
+func IsWebRTCDirectMultiaddr(addr multiaddr.Multiaddr) (bool, int) {
+	if webrtcMatchPrealloc == nil {
+		webrtcMatchPrealloc = preallocateCapture()
+	}
+	return webrtcMatchPrealloc.IsWebRTCDirectMultiaddr(addr)
+}
+
+// IsWebRTCDirectMultiaddrLoop returns whether addr is a /webrtc-direct multiaddr with the count of certhashes
+// in addr
+func IsWebRTCDirectMultiaddrLoop(addr multiaddr.Multiaddr) (bool, int) {
+	protos := [...]int{multiaddr.P_IP4, multiaddr.P_IP6, multiaddr.P_DNS, multiaddr.P_UDP, multiaddr.P_WEBRTC_DIRECT}
+	matchProtos := [...][]int{protos[:3], {protos[3]}, {protos[4]}}
+	certHashCount := 0
+	for i, c := range addr {
+		if i >= len(matchProtos) {
+			if c.Code() == multiaddr.P_CERTHASH {
+				certHashCount++
+			} else {
+				return false, 0
+			}
+		} else {
+			found := false
+			for _, proto := range matchProtos[i] {
+				if c.Code() == proto {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false, 0
+			}
+		}
+	}
+	return true, certHashCount
+}
+
+var wtPrealloc *preallocatedCapture
+
+func isWebTransportMultiaddrPrealloc() *preallocatedCapture {
+	if wtPrealloc != nil {
+		return wtPrealloc
+	}
+
+	p := &preallocatedCapture{}
+	var dnsName string
+	var ip4Addr string
+	var ip6Addr string
+	var udpPort string
+	var sni string
+	p.matcher = meg.PatternToMatchState(
+		meg.Or(
+			meg.CaptureVal(multiaddr.P_IP4, &ip4Addr),
+			meg.CaptureVal(multiaddr.P_IP6, &ip6Addr),
+			meg.CaptureVal(multiaddr.P_DNS4, &dnsName),
+			meg.CaptureVal(multiaddr.P_DNS6, &dnsName),
+			meg.CaptureVal(multiaddr.P_DNS, &dnsName),
+		),
+		meg.CaptureVal(multiaddr.P_UDP, &udpPort),
+		meg.Val(multiaddr.P_QUIC_V1),
+		meg.Optional(
+			meg.CaptureVal(multiaddr.P_SNI, &sni),
+		),
+		meg.Val(multiaddr.P_WEBTRANSPORT),
+		meg.CaptureZeroOrMore(multiaddr.P_CERTHASH, &p.certHashes),
+	)
+	wtPrealloc = p
+	return p
+}
+
+func IsWebTransportMultiaddrPrealloc(m multiaddr.Multiaddr) (bool, int) {
+	p := isWebTransportMultiaddrPrealloc()
+	found, _ := meg.Match(p.matcher, m)
+	return found, len(p.certHashes)
+}
+
+func IsWebTransportMultiaddr(m multiaddr.Multiaddr) (bool, int) {
+	var dnsName string
+	var ip4Addr string
+	var ip6Addr string
+	var udpPort string
+	var sni string
+	var certHashesStr []string
+	matched, _ := m.Match(
+		meg.Or(
+			meg.CaptureVal(multiaddr.P_IP4, &ip4Addr),
+			meg.CaptureVal(multiaddr.P_IP6, &ip6Addr),
+			meg.CaptureVal(multiaddr.P_DNS4, &dnsName),
+			meg.CaptureVal(multiaddr.P_DNS6, &dnsName),
+			meg.CaptureVal(multiaddr.P_DNS, &dnsName),
+		),
+		meg.CaptureVal(multiaddr.P_UDP, &udpPort),
+		meg.Val(multiaddr.P_QUIC_V1),
+		meg.Optional(
+			meg.CaptureVal(multiaddr.P_SNI, &sni),
+		),
+		meg.Val(multiaddr.P_WEBTRANSPORT),
+		meg.CaptureZeroOrMore(multiaddr.P_CERTHASH, &certHashesStr),
+	)
+	if !matched {
+		return false, 0
+	}
+	return true, len(certHashesStr)
+}
+
+func IsWebTransportMultiaddrNoCapture(m multiaddr.Multiaddr) (bool, int) {
+	matched, _ := m.Match(
+		meg.Or(
+			meg.Val(multiaddr.P_IP4),
+			meg.Val(multiaddr.P_IP6),
+			meg.Val(multiaddr.P_DNS4),
+			meg.Val(multiaddr.P_DNS6),
+			meg.Val(multiaddr.P_DNS),
+		),
+		meg.Val(multiaddr.P_UDP),
+		meg.Val(multiaddr.P_QUIC_V1),
+		meg.Optional(
+			meg.Val(multiaddr.P_SNI),
+		),
+		meg.Val(multiaddr.P_WEBTRANSPORT),
+		meg.ZeroOrMore(multiaddr.P_CERTHASH),
+	)
+	if !matched {
+		return false, 0
+	}
+	return true, 0
+}
+
+func IsWebTransportMultiaddrLoop(m multiaddr.Multiaddr) (bool, int) {
+	var ip4Addr string
+	var ip6Addr string
+	var dnsName string
+	var udpPort string
+	var sni string
+
+	// Expected pattern:
+	// 0: one of: P_IP4, P_IP6, P_DNS4, P_DNS6, P_DNS
+	// 1: P_UDP
+	// 2: P_QUIC_V1
+	// 3: optional P_SNI (if present)
+	// Next: P_WEBTRANSPORT
+	// Trailing: zero or more P_CERTHASH
+
+	// Check minimum length (at least without SNI: 4 components)
+	if len(m) < 4 {
+		return false, 0
+	}
+
+	idx := 0
+
+	// Component 0: Must be one of IP or DNS protocols.
+	switch m[idx].Code() {
+	case multiaddr.P_IP4:
+		ip4Addr = m[idx].String()
+	case multiaddr.P_IP6:
+		ip6Addr = m[idx].String()
+	case multiaddr.P_DNS4, multiaddr.P_DNS6, multiaddr.P_DNS:
+		dnsName = m[idx].String()
+	default:
+		return false, 0
+	}
+	idx++
+
+	// Component 1: Must be UDP.
+	if idx >= len(m) || m[idx].Code() != multiaddr.P_UDP {
+		return false, 0
+	}
+	udpPort = m[idx].String()
+	idx++
+
+	// Component 2: Must be QUIC_V1.
+	if idx >= len(m) || m[idx].Code() != multiaddr.P_QUIC_V1 {
+		return false, 0
+	}
+	idx++
+
+	// Optional component: SNI.
+	if idx < len(m) && m[idx].Code() == multiaddr.P_SNI {
+		sni = m[idx].String()
+		idx++
+	}
+
+	// Next component: Must be WEBTRANSPORT.
+	if idx >= len(m) || m[idx].Code() != multiaddr.P_WEBTRANSPORT {
+		return false, 0
+	}
+	idx++
+
+	// All remaining components must be CERTHASH.
+	certHashCount := 0
+	for ; idx < len(m); idx++ {
+		if m[idx].Code() != multiaddr.P_CERTHASH {
+			return false, 0
+		}
+		_ = m[idx].String()
+		certHashCount++
+	}
+
+	_ = ip4Addr
+	_ = ip6Addr
+	_ = dnsName
+	_ = udpPort
+	_ = sni
+
+	return true, certHashCount
+}
+
+func BenchmarkIsWebTransportMultiaddrPrealloc(b *testing.B) {
+	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/quic-v1/sni/example.com/webtransport")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWT, count := IsWebTransportMultiaddrPrealloc(addr)
+		if !isWT || count != 0 {
+			b.Fatal("unexpected result")
+		}
+	}
+}
+
+func BenchmarkIsWebTransportMultiaddrNoCapturePrealloc(b *testing.B) {
+	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/quic-v1/sni/example.com/webtransport")
+
+	wtPreallocNoCapture := meg.PatternToMatchState(
+		meg.Or(
+			meg.Val(multiaddr.P_IP4),
+			meg.Val(multiaddr.P_IP6),
+			meg.Val(multiaddr.P_DNS4),
+			meg.Val(multiaddr.P_DNS6),
+			meg.Val(multiaddr.P_DNS),
+		),
+		meg.Val(multiaddr.P_UDP),
+		meg.Val(multiaddr.P_QUIC_V1),
+		meg.Optional(
+			meg.Val(multiaddr.P_SNI),
+		),
+		meg.Val(multiaddr.P_WEBTRANSPORT),
+		meg.ZeroOrMore(multiaddr.P_CERTHASH),
+	)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWT, _ := meg.Match(wtPreallocNoCapture, addr)
+		if !isWT {
+			b.Fatal("unexpected result")
+		}
+	}
+}
+
+func BenchmarkIsWebTransportMultiaddrNoCapture(b *testing.B) {
+	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/quic-v1/sni/example.com/webtransport")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWT, count := IsWebTransportMultiaddrNoCapture(addr)
+		if !isWT || count != 0 {
+			b.Fatal("unexpected result")
+		}
+	}
+}
+
+func BenchmarkIsWebTransportMultiaddr(b *testing.B) {
+	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/quic-v1/sni/example.com/webtransport")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWT, count := IsWebTransportMultiaddr(addr)
+		if !isWT || count != 0 {
+			b.Fatal("unexpected result")
+		}
+	}
+}
+
+func BenchmarkIsWebTransportMultiaddrLoop(b *testing.B) {
+	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/quic-v1/sni/example.com/webtransport")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWT, count := IsWebTransportMultiaddrLoop(addr)
+		if !isWT || count != 0 {
+			b.Fatal("unexpected result")
+		}
+	}
+}
+
+func BenchmarkIsWebRTCDirectMultiaddr(b *testing.B) {
+	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/webrtc-direct/")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWebRTC, count := IsWebRTCDirectMultiaddr(addr)
+		if !isWebRTC || count != 0 {
+			b.Fatal("unexpected result")
+		}
+	}
+}
+
+func BenchmarkIsWebRTCDirectMultiaddrLoop(b *testing.B) {
+	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/webrtc-direct/")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		isWebRTC, count := IsWebRTCDirectMultiaddrLoop(addr)
+		if !isWebRTC || count != 0 {
+			b.Fatal("unexpected result")
+		}
+	}
+}

--- a/x/meg/bench_test.go
+++ b/x/meg/bench_test.go
@@ -14,7 +14,7 @@ type preallocatedCapture struct {
 
 func preallocateCapture() *preallocatedCapture {
 	p := &preallocatedCapture{}
-	p.matcher = meg.PatternToMatchState(
+	p.matcher = meg.PatternToMatcher(
 		meg.Or(
 			meg.Val(multiaddr.P_IP4),
 			meg.Val(multiaddr.P_IP6),
@@ -85,7 +85,7 @@ func isWebTransportMultiaddrPrealloc() *preallocatedCapture {
 	var ip6Addr string
 	var udpPort string
 	var sni string
-	p.matcher = meg.PatternToMatchState(
+	p.matcher = meg.PatternToMatcher(
 		meg.Or(
 			meg.CaptureVal(multiaddr.P_IP4, &ip4Addr),
 			meg.CaptureVal(multiaddr.P_IP6, &ip6Addr),
@@ -317,7 +317,7 @@ func BenchmarkIsWebTransportMultiaddrPrealloc(b *testing.B) {
 func BenchmarkIsWebTransportMultiaddrNoCapturePrealloc(b *testing.B) {
 	addr := multiaddr.StringCast("/ip4/1.2.3.4/udp/1234/quic-v1/sni/example.com/webtransport")
 
-	wtPreallocNoCapture := meg.PatternToMatchState(
+	wtPreallocNoCapture := meg.PatternToMatcher(
 		meg.Or(
 			meg.Val(multiaddr.P_IP4),
 			meg.Val(multiaddr.P_IP6),

--- a/x/meg/meg.go
+++ b/x/meg/meg.go
@@ -19,14 +19,17 @@ const (
 // MatchState is the Thompson NFA for a regular expression.
 type MatchState struct {
 	capture captureFunc
-	next    int
+	// next is is the index of the next state. in the MatchState array.
+	next int
 	// If codeOrKind is negative, it is a kind.
-	// If it is negative, but not a `done`, then it is the nextSplitIdx
+	// If it is negative, but not a `done`, then it is the index to the next split.
+	// This is done to keep the `MatchState` struct small and cache friendly.
 	codeOrKind int
 }
 
 type captureFunc func(string) error
 
+// capture is a linked list of capture funcs with values.
 type capture struct {
 	f    captureFunc
 	v    string
@@ -138,6 +141,8 @@ func Match[S ~[]T, T Matchable](matcher Matcher, components S) (bool, error) {
 	return false, nil
 }
 
+// appendState is a non-recursive way of appending states to statesAndCaptures.
+// If a state is a split, both branches are appended to statesAndCaptures.
 func appendState(arr statesAndCaptures, states []MatchState, stateIndex int, c *capture, visitedBitSet []uint64) statesAndCaptures {
 	// Local struct to hold state index and the associated capture pointer.
 	type task struct {

--- a/x/meg/meg.go
+++ b/x/meg/meg.go
@@ -9,28 +9,23 @@ import (
 	"fmt"
 )
 
-type stateKind uint8
+type stateKind = int
 
 const (
-	matchCode stateKind = iota
-	split
-	done
+	done stateKind = (iota * -1) - 1
+	// split anything else that is negative
 )
 
 // MatchState is the Thompson NFA for a regular expression.
-type Matcher = *MatchState
-
 type MatchState struct {
-	capture   captureFunc
-	next      *MatchState
-	nextSplit *MatchState
-
-	kind       stateKind
-	generation int
-	code       int
+	capture captureFunc
+	next    int
+	// If codeOrKind is negative, it is a kind.
+	// If it is negative, but not a `done`, then it is the nextSplitIdx
+	codeOrKind int
 }
 
-type captureFunc *func(string) error
+type captureFunc func(string) error
 
 type capture struct {
 	f    captureFunc
@@ -39,12 +34,18 @@ type capture struct {
 }
 
 type statesAndCaptures struct {
-	states   []*MatchState
+	states   []int
 	captures []*capture
 }
 
-func (s *MatchState) String() string {
-	return fmt.Sprintf("state{kind: %d, generation: %d, code: %d}", s.kind, s.generation, s.code)
+func (s MatchState) String() string {
+	if s.codeOrKind == done {
+		return "done"
+	}
+	if s.codeOrKind < done {
+		return fmt.Sprintf("split{left: %d, right: %d}", s.next, restoreSplitIdx(s.codeOrKind))
+	}
+	return fmt.Sprintf("match{code: %d, next: %d}", s.codeOrKind, s.next)
 }
 
 type Matchable interface {
@@ -55,27 +56,37 @@ type Matchable interface {
 // Match returns whether the given Components match the Pattern defined in MatchState.
 // Errors are used to communicate capture errors.
 // If the error is non-nil the returned bool will be false.
-func Match[S ~[]T, T Matchable](s *MatchState, components S) (bool, error) {
-	listGeneration := s.generation + 1               // Start at the last generation + 1
-	defer func() { s.generation = listGeneration }() // In case we reuse this state, store our highest generation number
+func Match[S ~[]T, T Matchable](matcher Matcher, components S) (bool, error) {
+	states := matcher.states
+	startStateIdx := matcher.startIdx
+
+	// Fast case for a small number of states (<128)
+	// Avoids allocation of a slice for the visitedBitSet.
+	stackBitSet := [2]uint64{}
+	visitedBitSet := stackBitSet[:]
+	if len(states) > 128 {
+		visitedBitSet = make([]uint64, (len(states)+63)/64)
+	}
 
 	currentStates := statesAndCaptures{
-		states:   make([]*MatchState, 0, 16),
+		states:   make([]int, 0, 16),
 		captures: make([]*capture, 0, 16),
 	}
 	nextStates := statesAndCaptures{
-		states:   make([]*MatchState, 0, 16),
+		states:   make([]int, 0, 16),
 		captures: make([]*capture, 0, 16),
 	}
 
-	currentStates = appendState(currentStates, s, nil, listGeneration)
+	currentStates = appendState(currentStates, states, startStateIdx, nil, visitedBitSet)
 
 	for _, c := range components {
+		clear(visitedBitSet)
 		if len(currentStates.states) == 0 {
 			return false, nil
 		}
-		for i, s := range currentStates.states {
-			if s.kind == matchCode && s.code == c.Code() {
+		for i, stateIndex := range currentStates.states {
+			s := states[stateIndex]
+			if s.codeOrKind >= 0 && s.codeOrKind == c.Code() {
 				cm := currentStates.captures[i]
 				if s.capture != nil {
 					next := &capture{
@@ -90,24 +101,36 @@ func Match[S ~[]T, T Matchable](s *MatchState, components S) (bool, error) {
 					}
 					currentStates.captures[i] = cm
 				}
-				nextStates = appendState(nextStates, s.next, cm, listGeneration)
+				nextStates = appendState(nextStates, states, s.next, cm, visitedBitSet)
 			}
 		}
 		currentStates, nextStates = nextStates, currentStates
 		nextStates.states = nextStates.states[:0]
 		nextStates.captures = nextStates.captures[:0]
-		listGeneration++
 	}
 
-	for i, s := range currentStates.states {
-		if s.kind == done {
+	for i, stateIndex := range currentStates.states {
+		s := states[stateIndex]
+		if s.codeOrKind == done {
+
 			// We found a complete path. Run the captures now
 			c := currentStates.captures[i]
+
+			// Flip the order of the captures because we see captures from right
+			// to left, but users expect them left to right.
+			type captureWithVal struct {
+				f captureFunc
+				v string
+			}
+			reversedCaptures := make([]captureWithVal, 0, 16)
 			for c != nil {
-				if err := (*c.f)(c.v); err != nil {
+				reversedCaptures = append(reversedCaptures, captureWithVal{c.f, c.v})
+				c = c.prev
+			}
+			for i := len(reversedCaptures) - 1; i >= 0; i-- {
+				if err := reversedCaptures[i].f(reversedCaptures[i].v); err != nil {
 					return false, err
 				}
-				c = c.prev
 			}
 			return true, nil
 		}
@@ -115,17 +138,57 @@ func Match[S ~[]T, T Matchable](s *MatchState, components S) (bool, error) {
 	return false, nil
 }
 
-func appendState(arr statesAndCaptures, s *MatchState, c *capture, listGeneration int) statesAndCaptures {
-	if s == nil || s.generation == listGeneration {
-		return arr
+func appendState(arr statesAndCaptures, states []MatchState, stateIndex int, c *capture, visitedBitSet []uint64) statesAndCaptures {
+	// Local struct to hold state index and the associated capture pointer.
+	type task struct {
+		idx int
+		cap *capture
 	}
-	s.generation = listGeneration
-	if s.kind == split {
-		arr = appendState(arr, s.next, c, listGeneration)
-		arr = appendState(arr, s.nextSplit, c, listGeneration)
-	} else {
-		arr.states = append(arr.states, s)
-		arr.captures = append(arr.captures, c)
+
+	// Initialize the stack with the starting task.
+	stack := make([]task, 0, 16)
+	stack = append(stack, task{stateIndex, c})
+
+	// Process the stack until empty.
+	for len(stack) > 0 {
+		// Pop the last element (LIFO order).
+		n := len(stack) - 1
+		t := stack[n]
+		stack = stack[:n]
+
+		// If the state index is out of bounds, skip.
+		if t.idx >= len(states) {
+			continue
+		}
+		s := states[t.idx]
+
+		// Check if this state has already been visited.
+		if visitedBitSet[t.idx/64]&(1<<(t.idx%64)) != 0 {
+			continue
+		}
+		// Mark the state as visited.
+		visitedBitSet[t.idx/64] |= 1 << (t.idx % 64)
+
+		// If it's a split state (the value is less than done) then push both branches.
+		if s.codeOrKind < done {
+			// Get the second branch from the split.
+			splitIdx := restoreSplitIdx(s.codeOrKind)
+			// To preserve order (s.next processed first), push the split branch first.
+			stack = append(stack, task{splitIdx, t.cap})
+			stack = append(stack, task{s.next, t.cap})
+		} else {
+			// Otherwise, it's a valid final state -- append it.
+			arr.states = append(arr.states, t.idx)
+			arr.captures = append(arr.captures, t.cap)
+		}
 	}
 	return arr
+}
+
+func storeSplitIdx(codeOrKind int) int {
+	return (codeOrKind + 2) * -1
+}
+
+func restoreSplitIdx(splitIdx int) int {
+	return (splitIdx * -1) - 2
 }

--- a/x/meg/meg.go
+++ b/x/meg/meg.go
@@ -18,6 +18,8 @@ const (
 )
 
 // MatchState is the Thompson NFA for a regular expression.
+type Matcher = *MatchState
+
 type MatchState struct {
 	capture   captureFunc
 	next      *MatchState

--- a/x/meg/meg_test.go
+++ b/x/meg/meg_test.go
@@ -1,7 +1,6 @@
 package meg
 
 import (
-	"fmt"
 	"regexp"
 	"slices"
 	"testing"
@@ -132,9 +131,7 @@ func TestCapture(t *testing.T) {
 				setup: func() (Matcher, func()) {
 					var code0strs []string
 					return PatternToMatchState(CaptureOneOrMore(0, &code0strs), Val(1)), func() {
-						// TODO flip the order here.
 						if code0strs[0] != "hello" {
-							fmt.Printf("code0strs: %v\n", code0strs)
 							panic("unexpected value")
 						}
 						if code0strs[1] != "world" {

--- a/x/meg/meg_test.go
+++ b/x/meg/meg_test.go
@@ -34,7 +34,7 @@ func TestSimple(t *testing.T) {
 	testCases :=
 		[]testCase{
 			{
-				pattern:     PatternToMatchState(Val(0), Val(1)),
+				pattern:     PatternToMatcher(Val(0), Val(1)),
 				shouldMatch: [][]int{{0, 1}},
 				shouldNotMatch: [][]int{
 					{0},
@@ -43,7 +43,7 @@ func TestSimple(t *testing.T) {
 				},
 			},
 			{
-				pattern: PatternToMatchState(Optional(Val(1))),
+				pattern: PatternToMatcher(Optional(Val(1))),
 				shouldMatch: [][]int{
 					{1},
 					{},
@@ -51,7 +51,7 @@ func TestSimple(t *testing.T) {
 				shouldNotMatch: [][]int{{0}},
 			},
 			{
-				pattern: PatternToMatchState(Val(0), Val(1), Optional(Val(2))),
+				pattern: PatternToMatcher(Val(0), Val(1), Optional(Val(2))),
 				shouldMatch: [][]int{
 					{0, 1, 2},
 					{0, 1},
@@ -62,7 +62,7 @@ func TestSimple(t *testing.T) {
 					{0, 1, 0},
 					{0, 1, 2, 0},
 				}}, {
-				pattern:        PatternToMatchState(Val(0), Val(1), OneOrMore(2)),
+				pattern:        PatternToMatcher(Val(0), Val(1), OneOrMore(2)),
 				skipQuickCheck: true,
 				shouldMatch: [][]int{
 					{0, 1, 2, 2, 2, 2},
@@ -119,7 +119,7 @@ func TestCapture(t *testing.T) {
 			{
 				setup: func() (Matcher, func()) {
 					var code0str string
-					return PatternToMatchState(CaptureVal(0, &code0str), Val(1)), func() {
+					return PatternToMatcher(CaptureVal(0, &code0str), Val(1)), func() {
 						if code0str != "hello" {
 							panic("unexpected value")
 						}
@@ -130,7 +130,7 @@ func TestCapture(t *testing.T) {
 			{
 				setup: func() (Matcher, func()) {
 					var code0strs []string
-					return PatternToMatchState(CaptureOneOrMore(0, &code0strs), Val(1)), func() {
+					return PatternToMatcher(CaptureOneOrMore(0, &code0strs), Val(1)), func() {
 						if code0strs[0] != "hello" {
 							panic("unexpected value")
 						}
@@ -228,7 +228,7 @@ func FuzzMatchesRegexpBehavior(f *testing.F) {
 			// Malformed regex. Ignore
 			return
 		}
-		p := PatternToMatchState(pattern...)
+		p := PatternToMatcher(pattern...)
 		otherMatched, _ := Match(p, bytesToCodeAndValue(corpus))
 		if otherMatched != matched {
 			t.Log("regexp", string(regexpPattern))

--- a/x/meg/meg_test.go
+++ b/x/meg/meg_test.go
@@ -233,25 +233,12 @@ func FuzzMatchesRegexpBehavior(f *testing.F) {
 		}
 		p := PatternToMatchState(pattern...)
 		otherMatched, _ := Match(p, bytesToCodeAndValue(corpus))
-		{
-			t.Log("regexp", string(regexpPattern))
-			t.Log("corpus", string(corpus))
-			t.Log("pattern", bytesToCodeAndValue(corpus))
-
-			a, b := Match(p, bytesToCodeAndValue(corpus))
-			t.Logf("Rerun: %v, %v", a, b)
-		}
 		if otherMatched != matched {
 			t.Log("regexp", string(regexpPattern))
 			t.Log("corpus", string(corpus))
 			m2, err2 := regexp.Match(string(regexpPattern), corpus)
 			t.Logf("regexp matched %v. %v. %v, %v. \n%v - \n%v", matched, err, m2, err2, regexpPattern, corpus)
 			t.Logf("pattern %+v", pattern)
-			{
-
-				a, b := Match(p, bytesToCodeAndValue(corpus))
-				t.Logf("Rerun: %v, %v", a, b)
-			}
 			t.Fatalf("mismatched results: %v %v %v", otherMatched, matched, p)
 		}
 	})

--- a/x/meg/sugar.go
+++ b/x/meg/sugar.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// Pattern is essentially a curried MatchState.
+// Given the slice of current MatchStates and a handle (int index) to the next
+// MatchState, it returns a handle to the inserted MatchState.
 type Pattern = func(states *[]MatchState, nextIdx int) int
 
 type Matcher struct {
@@ -22,9 +25,10 @@ func (s Matcher) String() string {
 	return fmt.Sprintf("RootMatchState{states: [%s], startIdx: %d}", strings.Join(states, ", "), s.startIdx)
 }
 
-func PatternToMatchState(patterns ...Pattern) Matcher {
+func PatternToMatcher(patterns ...Pattern) Matcher {
 	// Preallocate a slice to hold the MatchStates.
 	// Avoids small allocations for each pattern.
+	// The number is chosen experimentally. It is subject to change.
 	states := make([]MatchState, 0, len(patterns)*3)
 	// Append the done state.
 	states = append(states, MatchState{codeOrKind: done})


### PR DESCRIPTION
This PR stills needs some cleanup but sharing early to get some feedback.

This is overall 4x faster than the original PR for the normal case (no preallocation).

The main changes are:
- faster Code() method that avoids an unnecessary copy for the `Protocol` type. (I feel like this should have been optimized by the compiler though)
- Capture state is now a linked list rather than a map. This lets us "fork" states cheaply with structural sharing.
- Allocated MatchStates to a slice, and use indices as handles. This is a big change that does introduce a fair amount of complexity. I'll expand a bit on this next.

### MatchStates and Index handles:

By allocating to a single slice rather than the heap, we can prepare the memory upfront and reduce our overall memory pressure. We also make the `MatchState` much smaller (24 bytes from 48 bytes). The smaller size and having the states in contiguous memory enable it to be more cache friendly.

On my machine, with these changes, using Megular expressions normally is about as fast as the `ForEach` style in v0.14.

### Benchmark Results

Assume this system unless otherwise noted:
```
goos: darwin
goarch: arm64
pkg: github.com/multiformats/go-multiaddr
cpu: Apple M1 Max
```

go-multiaddr @ v0.14 using `.ForEach` https://github.com/multiformats/go-multiaddr/blob/marco/v0.14.0-bench/bench_test.go:
```
BenchmarkIsWebTransportMultiaddrForEach-10          1499752               783.0 ns/op          1912 B/op         13 allocs/op
```

The original megular expressions PR:
```
BenchmarkIsWebTransportMultiaddr-10       422496              2503 ns/op            2888 B/op         74 allocs/op
```

All but the Index handles change (the first two points from above):

```
BenchmarkIsWebTransportMultiaddrPrealloc-10                      2924878               414.3 ns/op           160 B/op          9 allocs/op
BenchmarkIsWebTransportMultiaddrNoCapturePrealloc-10             5895022               202.8 ns/op             0 B/op          0 allocs/op
BenchmarkIsWebTransportMultiaddrNoCapture-10                     1276366               937.1 ns/op          1144 B/op         28 allocs/op
BenchmarkIsWebTransportMultiaddr-10                               716146              1659 ns/op            1656 B/op         59 allocs/op
BenchmarkIsWebTransportMultiaddrLoop-10                          4707390               252.7 ns/op           136 B/op         12 allocs/op
```

With the index handles change
```
BenchmarkIsWebTransportMultiaddrPrealloc-10                      3011650               382.4 ns/op           160 B/op          9 allocs/op
BenchmarkIsWebTransportMultiaddrNoCapturePrealloc-10             6963790               171.7 ns/op             0 B/op          0 allocs/op
BenchmarkIsWebTransportMultiaddrNoCapture-10                     3364348               357.9 ns/op           472 B/op          2 allocs/op
BenchmarkIsWebTransportMultiaddr-10                              1377448               883.8 ns/op           920 B/op         25 allocs/op
BenchmarkIsWebTransportMultiaddrLoop-10                          4797229               250.4 ns/op           136 B/op         12 allocs/op
```

