### PR TITLE
refactor: remove .Empty

### DIFF
--- a/component.go
+++ b/component.go
@@ -20,7 +20,7 @@ type Component struct {
 }
 
 func (c *Component) AsMultiaddr() Multiaddr {
-	if c.Empty() {
+	if c == nil {
 		return nil
 	}
 	return []Component{*c}
@@ -32,13 +32,6 @@ func (c *Component) Encapsulate(o asMultiaddr) Multiaddr {
 
 func (c *Component) Decapsulate(o asMultiaddr) Multiaddr {
 	return c.AsMultiaddr().Decapsulate(o)
-}
-
-func (c *Component) Empty() bool {
-	if c == nil {
-		return true
-	}
-	return len(c.bytes) == 0
 }
 
 func (c *Component) Bytes() []byte {
@@ -178,9 +171,6 @@ func (c *Component) RawValue() []byte {
 
 func (c *Component) Value() string {
 	if c == nil {
-		return ""
-	}
-	if c.Empty() {
 		return ""
 	}
 	// This Component MUST have been checked by validateComponent when created

--- a/multiaddr.go
+++ b/multiaddr.go
@@ -25,18 +25,6 @@ func (m Multiaddr) copy() Multiaddr {
 	return out
 }
 
-func (m Multiaddr) Empty() bool {
-	if len(m) == 0 {
-		return true
-	}
-	for _, c := range m {
-		if !c.Empty() {
-			return false
-		}
-	}
-	return true
-}
-
 // NewMultiaddr parses and validates an input string, returning a *Multiaddr
 func NewMultiaddr(s string) (a Multiaddr, err error) {
 	defer func() {

--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -32,7 +32,6 @@ func TestReturnsNilOnEmpty(t *testing.T) {
 	require.Zero(t, len(a.Protocols()))
 	require.Nil(t, a)
 	require.Nil(t, c)
-	require.True(t, c.Empty())
 
 	// Test that empty multiaddr from various operations returns nil
 	a = StringCast("/ip4/1.2.3.4/tcp/1234")
@@ -45,7 +44,6 @@ func TestReturnsNilOnEmpty(t *testing.T) {
 	c, a = SplitFirst(nil)
 	require.Nil(t, a)
 	require.Nil(t, c)
-	require.True(t, c.Empty())
 
 	a = StringCast("/ip4/1.2.3.4/tcp/1234")
 	a = a.Decapsulate(a)
@@ -72,7 +70,8 @@ func TestReturnsNilOnEmpty(t *testing.T) {
 	_, err := NewMultiaddr("")
 	require.Error(t, err)
 
-	a = JoinComponents()
+	var nilMultiaddr Multiaddr
+	a = nilMultiaddr.AppendComponent()
 	require.Nil(t, a)
 
 	a = Join()
@@ -425,7 +424,7 @@ func TestBytesSplitAndJoin(t *testing.T) {
 			}
 		}
 
-		joined := JoinComponents(split...)
+		joined := append(Multiaddr{}, split...)
 		if !m.Equal(joined) {
 			t.Errorf("joined components failed: %s != %s", m, joined)
 		}
@@ -914,7 +913,7 @@ func TestComponentBinaryMarshaler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	comp2 := Component{}
+	var comp2 Component
 	if err = comp2.UnmarshalBinary(b); err != nil {
 		t.Fatal(err)
 	}
@@ -933,7 +932,7 @@ func TestComponentTextMarshaler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	comp2 := Component{}
+	var comp2 Component
 	if err = comp2.UnmarshalText(b); err != nil {
 		t.Fatal(err)
 	}
@@ -952,7 +951,7 @@ func TestComponentJSONMarshaler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	comp2 := Component{}
+	var comp2 Component
 	if err = comp2.UnmarshalJSON(b); err != nil {
 		t.Fatal(err)
 	}
@@ -993,7 +992,7 @@ func TestUseNilComponent(t *testing.T) {
 	foo.AsMultiaddr()
 	foo.Encapsulate(nil)
 	foo.Decapsulate(nil)
-	require.True(t, foo.Empty())
+	require.True(t, foo == nil)
 	foo.Bytes()
 	foo.MarshalBinary()
 	foo.MarshalJSON()

--- a/net/ip.go
+++ b/net/ip.go
@@ -64,7 +64,7 @@ func IsIPLoopback(m ma.Multiaddr) bool {
 		return false
 	}
 	c, _ := ma.SplitFirst(m)
-	if c.Empty() {
+	if c == nil {
 		return false
 	}
 	switch c.Protocol().Code {
@@ -83,7 +83,7 @@ func IsIP6LinkLocal(m ma.Multiaddr) bool {
 		return false
 	}
 	c, _ := ma.SplitFirst(m)
-	if c.Empty() || c.Protocol().Code != ma.P_IP6 {
+	if c == nil || c.Protocol().Code != ma.P_IP6 {
 		return false
 	}
 	ip := net.IP(c.RawValue())
@@ -106,11 +106,11 @@ func IsIPUnspecified(m ma.Multiaddr) bool {
 // else return m
 func zoneless(m ma.Multiaddr) ma.Multiaddr {
 	head, tail := ma.SplitFirst(m)
-	if head.Empty() {
+	if head == nil {
 		return nil
 	}
 	if head.Protocol().Code == ma.P_IP6ZONE {
-		if tail.Empty() {
+		if tail == nil {
 			return nil
 		}
 		tailhead, _ := ma.SplitFirst(tail)
@@ -127,6 +127,6 @@ func zoneless(m ma.Multiaddr) ma.Multiaddr {
 // used for NAT64 Translation. See RFC 6052
 func IsNAT64IPv4ConvertedIPv6Addr(addr ma.Multiaddr) bool {
 	c, _ := ma.SplitFirst(addr)
-	return !c.Empty() && c.Protocol().Code == ma.P_IP6 &&
+	return c != nil && c.Protocol().Code == ma.P_IP6 &&
 		inAddrRange(c.RawValue(), nat64)
 }

--- a/util.go
+++ b/util.go
@@ -9,19 +9,6 @@ func Split(m Multiaddr) []Component {
 	return m
 }
 
-func JoinComponents(cs ...Component) Multiaddr {
-	if len(cs) == 0 {
-		return nil
-	}
-	out := make([]Component, 0, len(cs))
-	for _, c := range cs {
-		if !c.Empty() {
-			out = append(out, c)
-		}
-	}
-	return out
-}
-
 // Join returns a combination of addresses.
 // Note: This copies all the components from the input Multiaddrs. Depending on
 // your use case, you may prefer to use `append(leftMA, rightMA...)` instead.
@@ -43,11 +30,7 @@ func Join(msInterfaces ...asMultiaddr) Multiaddr {
 
 	out := make([]Component, 0, size)
 	for _, m := range ms {
-		for _, c := range m {
-			if !c.Empty() {
-				out = append(out, c)
-			}
-		}
+		out = append(out, m...)
 	}
 	return out
 }
@@ -72,7 +55,7 @@ func StringCast(s string) Multiaddr {
 
 // SplitFirst returns the first component and the rest of the multiaddr.
 func SplitFirst(m Multiaddr) (*Component, Multiaddr) {
-	if m.Empty() {
+	if len(m) == 0 {
 		return nil, nil
 	}
 	if len(m) == 1 {
@@ -85,7 +68,7 @@ func SplitFirst(m Multiaddr) (*Component, Multiaddr) {
 
 // SplitLast returns the rest of the multiaddr and the last component.
 func SplitLast(m Multiaddr) (Multiaddr, *Component) {
-	if m.Empty() {
+	if len(m) == 0 {
 		return nil, nil
 	}
 	if len(m) == 1 {
@@ -101,7 +84,7 @@ func SplitLast(m Multiaddr) (Multiaddr, *Component) {
 // component on which the callback first returns will be included in the
 // *second* multiaddr.
 func SplitFunc(m Multiaddr, cb func(Component) bool) (Multiaddr, Multiaddr) {
-	if m.Empty() {
+	if len(m) == 0 {
 		return nil, nil
 	}
 
@@ -113,10 +96,10 @@ func SplitFunc(m Multiaddr, cb func(Component) bool) (Multiaddr, Multiaddr) {
 		}
 	}
 	pre, post := m[:idx], m[idx:]
-	if pre.Empty() {
+	if len(pre) == 0 {
 		pre = nil
 	}
-	if post.Empty() {
+	if len(post) == 0 {
 		post = nil
 	}
 	// defensive copy. Users can avoid by doing the split themselves.
@@ -128,7 +111,7 @@ func SplitFunc(m Multiaddr, cb func(Component) bool) (Multiaddr, Multiaddr) {
 // This function iterates over components.
 // Return true to continue iteration, false to stop.
 //
-// Prefer to use a standard for range loop instead
+// Prefer a standard for range loop instead
 // e.g. `for _, c := range m { ... }`
 func ForEach(m Multiaddr, cb func(c Component) bool) {
 	for _, c := range m {

--- a/util_test.go
+++ b/util_test.go
@@ -21,8 +21,8 @@ func TestSplitFirstLast(t *testing.T) {
 		head, tail := SplitFirst(addr)
 		rest, last := SplitLast(addr)
 		if len(x) == 0 {
-			if !head.Empty() {
-				t.Error("expected head to be empty")
+			if head != nil {
+				t.Error("expected head to be nil")
 			}
 			if tail != nil {
 				t.Error("expected tail to be nil")
@@ -30,8 +30,8 @@ func TestSplitFirstLast(t *testing.T) {
 			if rest != nil {
 				t.Error("expected rest to be nil")
 			}
-			if !last.Empty() {
-				t.Error("expected last to be empty")
+			if last != nil {
+				t.Error("expected last to be nil")
 			}
 			continue
 		}
@@ -122,7 +122,7 @@ func TestSplitFunc(t *testing.T) {
 				return c.AsMultiaddr().Equal(target)
 			})
 			if i == 0 {
-				if !a.Empty() {
+				if a != nil {
 					t.Error("expected nil addr")
 				}
 			} else {
@@ -135,7 +135,7 @@ func TestSplitFunc(t *testing.T) {
 			}
 		}
 		a, b := SplitFunc(addr, func(_ Component) bool { return false })
-		if !a.Equal(addr) || !b.Empty() {
+		if !a.Equal(addr) || b != nil {
 			t.Error("should not have split")
 		}
 	}


### PR DESCRIPTION
prefer the simpler `len` check for Multiaddr and `== nil` for `*Component`.

This helps with backward compatibility with v0.14. For example, this change: https://github.com/filecoin-project/lotus/pull/12912/files#diff-dd6a7924e7591cf2ed56af793a333f61f17a4a472d0ea542334ff841f5918c0dL63 would no longer be required.