### PR TITLE
feature: provide InterfaceMultiaddrsFor

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -392,7 +392,13 @@ func InterfaceMultiaddrs() ([]ma.Multiaddr, error) {
 		return nil, err
 	}
 
+	return InterfaceMultiaddrsFor(addrs)
+}
+
+// InterfaceMultiaddrsFor will return the addresses matching the given addrs
+func InterfaceMultiaddrsFor(addrs []net.Addr) ([]ma.Multiaddr, error) {
 	maddrs := make([]ma.Multiaddr, len(addrs))
+	var err error
 	for i, a := range addrs {
 		maddrs[i], err = FromNetAddr(a)
 		if err != nil {


### PR DESCRIPTION
net.InterfaceAddrs calls fail on android. This function allows specifying your own set of addresses, so another api can be used to avoid the issue.

See: https://github.com/multiformats/go-multiaddr/pull/255#issuecomment-2406974680

Closes #255