### PR TITLE
Add support for SCION addresses

### DIFF
--- a/protocols.go
+++ b/protocols.go
@@ -42,6 +42,7 @@ const (
 	P_WEBRTC_DIRECT     = 280
 	P_WEBRTC            = 281
 	P_MEMORY            = 777
+	P_SCION             = 13639680
 )
 
 var (
@@ -290,6 +291,14 @@ var (
 		Size:       64,
 		Transcoder: TranscoderMemory,
 	}
+	protoSCION = Protocol{
+		Name:       "scion",
+		Code:       P_SCION,
+		VCode:      CodeToVarint(P_SCION),
+		Size:       LengthPrefixedVarSize,
+		Path:       false,
+		Transcoder: TranscoderSCION,
+	}
 )
 
 func init() {
@@ -332,6 +341,7 @@ func init() {
 		protoWebRTCDirect,
 		protoWebRTC,
 		protoMemory,
+		protoSCION,
 	} {
 		if err := AddProtocol(p); err != nil {
 			panic(err)

--- a/transcoders.go
+++ b/transcoders.go
@@ -518,3 +518,32 @@ func memoryValidate(b []byte) error {
 
 	return nil
 }
+var TranscoderSCION = NewTranscoderFromFunctions(scionStB, scionBtS, scionVal)
+
+func scionVal(b []byte) error {
+	// SCION IA is 16 bit ISD and 48 bit AS numbers separated by "-"
+	// ISD numbers formatted as decimal, AS numbering similar to IPv6
+	// E.g.: "0-0" or "1234-ff00:0:110"
+	if len(b) < 3 {
+		return fmt.Errorf("byte slice too short: %d", len(b))
+	}
+	if minus := bytes.IndexByte(b, '-'); minus < 0 {
+		return errors.New("scion addresses must contain '-'")
+	}
+	return nil
+}
+
+func scionStB(s string) ([]byte, error) {
+	b := []byte(s)
+	if err := scionVal(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func scionBtS(b []byte) (string, error) {
+	if err := scionVal(b); err != nil {
+		return "", err
+	}
+	return string(b), nil
+}


### PR DESCRIPTION
Hey everyone, 

We'd like to upstream libp2p support for the SCION [1] Internet architecture and are therefor aiming to add scion to the multiaddr repo as preliminary step.

This PR adds support for multiaddrs like `/scion/19-ffaa:1:1079`. SCION IAs consist of a 16-bit ISD and a 48-bit AS number separated by -. ISD numbers are formatted as decimal (19), AS numbering is similar to IPv6 (ffaa:1:1079). [2]. A SCION multiaddr can encapsulate an IP address to specify an endpoint, e.g. /scion/19-ffaa:1:1079/ip4/127.0.0.1. 

Notably, SCION is a routing protocol that also provides its own address format (specifically ISD-AS) but for host-addresses themselves (inside the ASes) regular IPv4/IPv6 addressing is used. That's why we see great fit here in the multiaddr repo!

We have already reserved a corresponding protocol identifier in https://github.com/multiformats/multicodec/pull/325. There also is an experimental go-libp2p SCION+QUIC transport available at https://github.com/netsys-lab/go-libp2p/commit/7ea953ad7fed3715b5c9cc1ae4e12e381425c87d.

Looking forward to your feedback!

Cheers, 
Marten

Footnotes
[1] https://scion-architecture.net/ 
[2] https://docs.scion.org/en/latest/overview.html#isd-and-as-numbering